### PR TITLE
fallback to enqueue_copy if enqueue_fill is not available

### DIFF
--- a/kernel_tuner/opencl.py
+++ b/kernel_tuner/opencl.py
@@ -166,7 +166,7 @@ class OpenCLFunctions(object):
             try:
               cl.enqueue_fill_buffer(self.queue, buffer, numpy.uint32(value), 0, size)
             except:
-              src=numpy.zeros(size/4, dtype='uint32')+numpy.uint32(value)
+              src=numpy.zeros(size, dtype='uint8')+numpy.uint8(value)
               cl.enqueue_copy(self.queue, buffer, src)
 
     def memcpy_dtoh(self, dest, src):

--- a/kernel_tuner/opencl.py
+++ b/kernel_tuner/opencl.py
@@ -163,7 +163,11 @@ class OpenCLFunctions(object):
 
         """
         if isinstance(buffer, cl.Buffer):
-            cl.enqueue_fill_buffer(self.queue, buffer, numpy.uint32(value), 0, size)
+            try:
+              cl.enqueue_fill_buffer(self.queue, buffer, numpy.uint32(value), 0, size)
+            except:
+              src=numpy.zeros(size/4, dtype='uint32')+numpy.uint32(value)
+              cl.enqueue_copy(self.queue, buffer, src)
 
     def memcpy_dtoh(self, dest, src):
         """perform a device to host memory copy


### PR DESCRIPTION
this patch could be considered for inclusion, this fixes the matmul example on my (admittedly ancient) installation by including a fallback for enqueue_fill_buffer (not present in opencl 1.1)

a very good reason not to include this is that other things could be broken for 1.1 (Which you don't want to run around be maintaining)!!