### PR TITLE
Parsing argument lists

### DIFF
--- a/kernel_tuner/interface.py
+++ b/kernel_tuner/interface.py
@@ -299,7 +299,7 @@ def tune_kernel(kernel_name, kernel_string, problem_size, arguments,
 
     # see if the kernel arguments have correct type
     if not callable(kernel_string):
-        util.check_argument_list(util.get_kernel_string(kernel_string), arguments)
+        util.check_argument_list(kernel_name, util.get_kernel_string(kernel_string), arguments)
     else:
         logging.debug("Checking of arguments list not supported yet for code generators.")
 
@@ -448,7 +448,7 @@ def run_kernel(kernel_name, kernel_string, problem_size, arguments,
             raise Exception("cannot create kernel instance, too many threads per block")
 
         # see if the kernel arguments have correct type
-        util.check_argument_list(instance.kernel_string, arguments)
+        util.check_argument_list(instance.name, instance.kernel_string, arguments)
 
         #compile the kernel
         func = dev.compile_kernel(instance, False)

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -13,8 +13,8 @@ default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 
 def check_argument_list(kernel_name, kernel_string, args):
     """ raise an exception if a kernel arguments do not match host arguments """
-    kernel_start = kernel_string.find(kernel_name + "(")
-    kernel_start = kernel_start + len(kernel_name) + 1
+    kernel_start = kernel_string.find(kernel_name)
+    kernel_start = kernel_string.find("(", kernel_start) + 1
     kernel_end = kernel_string.find(")", kernel_start)
     kernel_arguments = kernel_string[kernel_start:kernel_end].split(",")
     if len(kernel_arguments) != len(args):

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -11,9 +11,9 @@ import warnings
 
 default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 
-def check_argument_list(kernel_string, args):
+def check_argument_list(kernel_name, kernel_string, args):
     """ raise an exception if a kernel arguments do not match host arguments """
-    kernel_arguments = kernel_string[kernel_string.find("(") + 1:kernel_string.find(")")].split(",")
+    kernel_arguments = kernel_string[kernel_string.find(kernel_name + "(") + 1:kernel_string.find(")")].split(",")
     if len(kernel_arguments) != len(args):
         raise TypeError("Kernel and host argument lists do not match in size.")
     for (i, arg) in enumerate(args):

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -13,7 +13,10 @@ default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 
 def check_argument_list(kernel_name, kernel_string, args):
     """ raise an exception if a kernel arguments do not match host arguments """
-    kernel_arguments = kernel_string[kernel_string.find(kernel_name + "(") + 1:kernel_string.find(")")].split(",")
+    kernel_start = kernel_string.find(kernel_name + "(")
+    kernel_start = kernel_start + len(kernel_name) + 1
+    kernel_end = kernel_string.find(")", kernel_start)
+    kernel_arguments = kernel_string[kernel_start:kernel_end].split(",")
     if len(kernel_arguments) != len(args):
         raise TypeError("Kernel and host argument lists do not match in size.")
     for (i, arg) in enumerate(args):

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -275,6 +275,37 @@ def test_check_argument_list4():
         print("Expected a TypeError to be raised")
         assert False
 
+def test_check_argument_list5():
+    kernel_string = """ //more complicated test function(because I can)
+
+        __device__ float some_lame_device_function(float *a) {
+            return a[0];
+        }
+
+        __global__ void my_test_kernel(double *a,
+                                       float *b, int c,
+                                       int d) {
+
+            a[threadIdx.x] = b[blockIdx.x]*c*d;
+        }
+        """
+    args = [numpy.array([1,2,3]).astype(numpy.float64),
+            numpy.array([1,2,3]).astype(numpy.float32),
+            numpy.int32(6), numpy.int32(7)]
+
+    #print what check_argument_list is doing as well
+    kernel_arguments = kernel_string[kernel_string.find("(") + 1:kernel_string.find(")")].split(",")
+
+    print(kernel_arguments)
+
+    try:
+        check_argument_list(kernel_string, args)
+
+    except TypeError as expected_error:
+        print("Expected no TypeError to be raised")
+        assert False
+
+
 def test_check_tune_params_list():
     tune_params = dict(zip(["one_thing", "led_to_another", "and_before_you_know_it",
                             "grid_size_y"], [1, 2, 3, 4]))

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -234,7 +234,8 @@ def test_check_argument_list1():
 
 def test_check_argument_list2():
     kernel_name = "test_kernel"
-    kernel_string = """__kernel void test_kernel(char number, double factors, int * numbers, const unsigned long * moreNumbers) {
+    kernel_string = """__kernel void test_kernel
+        (char number, double factors, int * numbers, const unsigned long * moreNumbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """
@@ -245,7 +246,7 @@ def test_check_argument_list2():
 
 def test_check_argument_list3():
     kernel_name = "test_kernel"
-    kernel_string = """__kernel void test_kernel(__global const ushort number, __global half * factors, __global long * numbers) {
+    kernel_string = """__kernel void test_kernel (__global const ushort number, __global half * factors, __global long * numbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -215,13 +215,14 @@ def test_get_device_interface3():
         core.DeviceInterface("", 0, 0, lang=lang)
 
 def test_check_argument_list1():
+    kernel_name = "test_kernel"
     kernel_string = """__kernel void test_kernel(int number, char * message, int * numbers) {
     numbers[get_global_id(0)] = numbers[get_global_id(0)] * number;
     }
     """
     args = [numpy.int32(5), 'blah', numpy.array([1, 2, 3])]
     try:
-        check_argument_list(kernel_string, args)
+        check_argument_list(kernel_name, kernel_string, args)
         print("Expected a TypeError to be raised")
         assert False
     except TypeError as e:
@@ -232,23 +233,25 @@ def test_check_argument_list1():
         assert False
 
 def test_check_argument_list2():
+    kernel_name = "test_kernel"
     kernel_string = """__kernel void test_kernel(char number, double factors, int * numbers, const unsigned long * moreNumbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """
     args = [numpy.byte(5), numpy.float64(4.6), numpy.int32([1, 2, 3]), numpy.uint64([3, 2, 111])]
-    check_argument_list(kernel_string, args)
+    check_argument_list(kernel_name, kernel_string, args)
     #test that no exception is raised
     assert True
 
 def test_check_argument_list3():
+    kernel_name = "test_kernel"
     kernel_string = """__kernel void test_kernel(__global const ushort number, __global half * factors, __global long * numbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """
     args = [numpy.uint16(42), numpy.float16([3, 4, 6]), numpy.int32([300])]
     try:
-        check_argument_list(kernel_string, args)
+        check_argument_list(kernel_name, kernel_string, args)
         print("Expected a TypeError to be raised")
         assert False
     except TypeError as expected_error:
@@ -259,13 +262,14 @@ def test_check_argument_list3():
         assert False
 
 def test_check_argument_list4():
+    kernel_name = "test_kernel"
     kernel_string = """__kernel void test_kernel(__global const ushort number, __global half * factors, __global long * numbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """
     args = [numpy.uint16(42), numpy.float16([3, 4, 6]), numpy.int64([300]), numpy.ubyte(32)]
     try:
-        check_argument_list(kernel_string, args)
+        check_argument_list(kernel_name, kernel_string, args)
         print("Expected a TypeError to be raised")
         assert False
     except TypeError as expected_error:
@@ -276,6 +280,7 @@ def test_check_argument_list4():
         assert False
 
 def test_check_argument_list5():
+    kernel_name = "my_test_kernel"
     kernel_string = """ //more complicated test function(because I can)
 
         __device__ float some_lame_device_function(float *a) {
@@ -299,7 +304,7 @@ def test_check_argument_list5():
     print(kernel_arguments)
 
     try:
-        check_argument_list(kernel_string, args)
+        check_argument_list(kernel_name, kernel_string, args)
 
     except TypeError as expected_error:
         print("Expected no TypeError to be raised")

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -299,11 +299,6 @@ def test_check_argument_list5():
             numpy.array([1,2,3]).astype(numpy.float32),
             numpy.int32(6), numpy.int32(7)]
 
-    #print what check_argument_list is doing as well
-    kernel_arguments = kernel_string[kernel_string.find("(") + 1:kernel_string.find(")")].split(",")
-
-    print(kernel_arguments)
-
     try:
         check_argument_list(kernel_name, kernel_string, args)
 


### PR DESCRIPTION
The test does not fail anymore. Also changed a couple of tests to add some blank characters between the kernel name and the beginning of the arguments.