### PR TITLE
Parsing argument lists

### DIFF
--- a/kernel_tuner/interface.py
+++ b/kernel_tuner/interface.py
@@ -299,7 +299,7 @@ def tune_kernel(kernel_name, kernel_string, problem_size, arguments,
 
     # see if the kernel arguments have correct type
     if not callable(kernel_string):
-        util.check_argument_list(util.get_kernel_string(kernel_string), arguments)
+        util.check_argument_list(kernel_name, util.get_kernel_string(kernel_string), arguments)
     else:
         logging.debug("Checking of arguments list not supported yet for code generators.")
 
@@ -448,7 +448,7 @@ def run_kernel(kernel_name, kernel_string, problem_size, arguments,
             raise Exception("cannot create kernel instance, too many threads per block")
 
         # see if the kernel arguments have correct type
-        util.check_argument_list(instance.kernel_string, arguments)
+        util.check_argument_list(instance.name, instance.kernel_string, arguments)
 
         #compile the kernel
         func = dev.compile_kernel(instance, False)

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -16,9 +16,8 @@ def check_argument_list(kernel_name, kernel_string, args):
     """ raise an exception if a kernel arguments do not match host arguments """
     kernel_arguments = list()
     collected_errors = list()
-    for iterator in re.finditer(kernel_name, kernel_string):
-        kernel_start = iterator.start()
-        kernel_start = kernel_string.find("(", kernel_start) + 1
+    for iterator in re.finditer(kernel_name + "[ \n\t]*" + "\(", kernel_string):
+        kernel_start = iterator.end()
         kernel_end = kernel_string.find(")", kernel_start)
         if kernel_start != 0:
             kernel_arguments.append(kernel_string[kernel_start:kernel_end].split(","))

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -8,100 +8,113 @@ import tempfile
 import logging
 import numpy
 import warnings
+import re
 
 default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 
 def check_argument_list(kernel_name, kernel_string, args):
     """ raise an exception if a kernel arguments do not match host arguments """
-    kernel_start = kernel_string.find(kernel_name)
-    kernel_start = kernel_string.find("(", kernel_start) + 1
-    kernel_end = kernel_string.find(")", kernel_start)
-    kernel_arguments = kernel_string[kernel_start:kernel_end].split(",")
-    if len(kernel_arguments) != len(args):
-        raise TypeError("Kernel and host argument lists do not match in size.")
-    for (i, arg) in enumerate(args):
-        kernel_argument = kernel_arguments[i]
-        if "*" in kernel_argument:
-            # Corresponding argument should be a NumPy array
-            if not isinstance(arg, numpy.ndarray):
-                raise TypeError("Argument at position " + str(i) + " of type: "
+    kernel_arguments = list()
+    collected_errors = list()
+    for iterator in re.finditer(kernel_name, kernel_string):
+        kernel_start = iterator.start()
+        kernel_start = kernel_string.find("(", kernel_start) + 1
+        kernel_end = kernel_string.find(")", kernel_start)
+        if kernel_start != 0:
+            kernel_arguments.append(kernel_string[kernel_start:kernel_end].split(","))
+    for arguments_set, arguments in enumerate(kernel_arguments):
+        collected_errors.append(list())
+        if len(arguments) != len(args):
+            collected_errors[arguments_set].append("Kernel and host argument lists do not match in size.")
+            continue
+        for (i, arg) in enumerate(args):
+            kernel_argument = arguments[i]
+            if "*" in kernel_argument:
+                # Corresponding argument should be a NumPy array
+                if not isinstance(arg, numpy.ndarray):
+                    collected_errors[arguments_set].append("Argument at position " + str(i) + " of type: "
+                        + str(type(arg)) + " does not match " + kernel_argument + ".")
+                    continue
+                # CUDA/OpenCL/C uchar arrays
+                if ("uchar" in kernel_argument or "unsigned char" in kernel_argument) and arg.dtype == "ubyte":
+                    continue
+                # CUDA/OpenCL/C char arrays
+                elif "char" in kernel_argument and arg.dtype == "byte":
+                    continue
+                # CUDA/OpenCL/C ushort arrays
+                elif ("ushort" in kernel_argument or "unsigned short" in kernel_argument) and arg.dtype == "uint16":
+                    continue
+                # CUDA/OpenCL/C short arrays
+                elif "short" in kernel_argument and arg.dtype == "int16":
+                    continue
+                # CUDA/OpenCL/C uint arrays
+                elif ("uint" in kernel_argument or "unsigned int" in kernel_argument) and arg.dtype == "uint32":
+                    continue
+                # CUDA/OpenCL/C int arrays
+                elif "int" in kernel_argument and arg.dtype == "int32":
+                    continue
+                # CUDA/OpenCL/C ulong arrays
+                elif ("ulong" in kernel_argument or "unsigned long" in kernel_argument) and arg.dtype == "uint64":
+                    continue
+                # CUDA/OpenCL/C long arrays
+                elif "long" in kernel_argument and arg.dtype == "int64":
+                    continue
+                # OpenCL/C half arrays
+                elif "half" in kernel_argument and arg.dtype == "float16":
+                    continue
+                # CUDA/OpenCL/C float arrays
+                elif "float" in kernel_argument and arg.dtype == "float32":
+                    continue
+                # CUDA/OpenCL/C double array
+                elif "double" in kernel_argument and arg.dtype == "float64":
+                    continue
+                collected_errors[arguments_set].append("Argument at position " + str(i) + " of type: "
                     + str(type(arg)) + " does not match " + kernel_argument + ".")
-            # CUDA/OpenCL/C uchar arrays
-            if ("uchar" in kernel_argument or "unsigned char" in kernel_argument) and arg.dtype == "ubyte":
-                continue
-            # CUDA/OpenCL/C char arrays
-            elif "char" in kernel_argument and arg.dtype == "byte":
-                continue
-            # CUDA/OpenCL/C ushort arrays
-            elif ("ushort" in kernel_argument or "unsigned short" in kernel_argument) and arg.dtype == "uint16":
-                continue
-            # CUDA/OpenCL/C short arrays
-            elif "short" in kernel_argument and arg.dtype == "int16":
-                continue
-            # CUDA/OpenCL/C uint arrays
-            elif ("uint" in kernel_argument or "unsigned int" in kernel_argument) and arg.dtype == "uint32":
-                continue
-            # CUDA/OpenCL/C int arrays
-            elif "int" in kernel_argument and arg.dtype == "int32":
-                continue
-            # CUDA/OpenCL/C ulong arrays
-            elif ("ulong" in kernel_argument or "unsigned long" in kernel_argument) and arg.dtype == "uint64":
-                continue
-            # CUDA/OpenCL/C long arrays
-            elif "long" in kernel_argument and arg.dtype == "int64":
-                continue
-            # OpenCL/C half arrays
-            elif "half" in kernel_argument and arg.dtype == "float16":
-                continue
-            # CUDA/OpenCL/C float arrays
-            elif "float" in kernel_argument and arg.dtype == "float32":
-                continue
-            # CUDA/OpenCL/C double array
-            elif "double" in kernel_argument and arg.dtype == "float64":
-                continue
-            raise TypeError("Argument at position " + str(i) + " of type: "
-                + str(type(arg)) + " does not match " + kernel_argument + ".")
-        else:
-            # NumPy scalar
-            if not isinstance(arg, numpy.generic):
-                raise TypeError("Argument at position " + str(i) + " of type: "
+            else:
+                # NumPy scalar
+                if not isinstance(arg, numpy.generic):
+                    collected_errors[arguments_set].append("Argument at position " + str(i) + " of type: "
+                        + str(type(arg)) + " does not match " + kernel_argument + ".")
+                    continue
+                # CUDA/OpenCL/C uchar
+                if ("uchar" in kernel_argument or "unsigned char" in kernel_argument) and arg.dtype == "ubyte":
+                    continue
+                # CUDA/OpenCL/C char
+                elif "char" in kernel_argument and arg.dtype == "byte":
+                    continue
+                # CUDA/OpenCL/C ushort
+                elif ("ushort" in kernel_argument or "unsigned short" in kernel_argument) and arg.dtype == "ushort":
+                    continue
+                # CUDA/OpenCL/C short
+                elif "short" in kernel_argument and arg.dtype == "short":
+                    continue
+                # CUDA/OpenCL/C uint
+                elif ("uint" in kernel_argument or "unsigned int" in kernel_argument) and arg.dtype == "uint32":
+                    continue
+                # CUDA/OpenCL/C int
+                elif "int" in kernel_argument and arg.dtype == "int32":
+                    continue
+                # CUDA/OpenCL/C ulong
+                elif ("ulong" in kernel_argument or "unsigned long" in kernel_argument) and arg.dtype == "uint64":
+                    continue
+                # CUDA/OpenCL/C long
+                elif "long" in kernel_argument and arg.dtype == "int64":
+                    continue
+                # OpenCL/C half
+                elif "half" in kernel_argument and arg.dtype == "float16":
+                    continue
+                # CUDA/OpenCL/C float
+                elif "float" in kernel_argument and arg.dtype == "float32":
+                    continue
+                # CUDA/OpenCL/C double
+                elif "double" in kernel_argument and arg.dtype == "float64":
+                    continue
+                collected_errors[arguments_set].append("Argument at position " + str(i) + " of type: "
                     + str(type(arg)) + " does not match " + kernel_argument + ".")
-            # CUDA/OpenCL/C uchar
-            if ("uchar" in kernel_argument or "unsigned char" in kernel_argument) and arg.dtype == "ubyte":
-                continue
-            # CUDA/OpenCL/C char
-            elif "char" in kernel_argument and arg.dtype == "byte":
-                continue
-            # CUDA/OpenCL/C ushort
-            elif ("ushort" in kernel_argument or "unsigned short" in kernel_argument) and arg.dtype == "ushort":
-                continue
-            # CUDA/OpenCL/C short
-            elif "short" in kernel_argument and arg.dtype == "short":
-                continue
-            # CUDA/OpenCL/C uint
-            elif ("uint" in kernel_argument or "unsigned int" in kernel_argument) and arg.dtype == "uint32":
-                continue
-            # CUDA/OpenCL/C int
-            elif "int" in kernel_argument and arg.dtype == "int32":
-                continue
-            # CUDA/OpenCL/C ulong
-            elif ("ulong" in kernel_argument or "unsigned long" in kernel_argument) and arg.dtype == "uint64":
-                continue
-            # CUDA/OpenCL/C long
-            elif "long" in kernel_argument and arg.dtype == "int64":
-                continue
-            # OpenCL/C half
-            elif "half" in kernel_argument and arg.dtype == "float16":
-                continue
-            # CUDA/OpenCL/C float
-            elif "float" in kernel_argument and arg.dtype == "float32":
-                continue
-            # CUDA/OpenCL/C double
-            elif "double" in kernel_argument and arg.dtype == "float64":
-                continue
-            raise TypeError("Argument at position " + str(i) + " of type: "
-                + str(type(arg)) + " does not match " + kernel_argument + ".")
-
+        if len(collected_errors[arguments_set]) == 0:
+            # We assume that if there is a possible list of arguments that matches with the provided one
+            # it is the right one
+            return
 
 def check_tune_params_list(tune_params):
     """ raise an exception if a tune parameter has a forbidden name """

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -115,6 +115,7 @@ def check_argument_list(kernel_name, kernel_string, args):
             # We assume that if there is a possible list of arguments that matches with the provided one
             # it is the right one
             return
+    raise TypeError(collected_errors[0][0])
 
 def check_tune_params_list(tune_params):
     """ raise an exception if a tune parameter has a forbidden name """

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -13,8 +13,8 @@ default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 
 def check_argument_list(kernel_name, kernel_string, args):
     """ raise an exception if a kernel arguments do not match host arguments """
-    kernel_start = kernel_string.find(kernel_name + "(")
-    kernel_start = kernel_start + len(kernel_name) + 1
+    kernel_start = kernel_string.find(kernel_name)
+    kernel_start = kernel_string.find("(", kernel_start) + 1
     kernel_end = kernel_string.find(")", kernel_start)
     kernel_arguments = kernel_string[kernel_start:kernel_end].split(",")
     if len(kernel_arguments) != len(args):

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -11,9 +11,9 @@ import warnings
 
 default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 
-def check_argument_list(kernel_string, args):
+def check_argument_list(kernel_name, kernel_string, args):
     """ raise an exception if a kernel arguments do not match host arguments """
-    kernel_arguments = kernel_string[kernel_string.find("(") + 1:kernel_string.find(")")].split(",")
+    kernel_arguments = kernel_string[kernel_string.find(kernel_name + "(") + 1:kernel_string.find(")")].split(",")
     if len(kernel_arguments) != len(args):
         raise TypeError("Kernel and host argument lists do not match in size.")
     for (i, arg) in enumerate(args):

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -13,7 +13,10 @@ default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 
 def check_argument_list(kernel_name, kernel_string, args):
     """ raise an exception if a kernel arguments do not match host arguments """
-    kernel_arguments = kernel_string[kernel_string.find(kernel_name + "(") + 1:kernel_string.find(")")].split(",")
+    kernel_start = kernel_string.find(kernel_name + "(")
+    kernel_start = kernel_start + len(kernel_name) + 1
+    kernel_end = kernel_string.find(")", kernel_start)
+    kernel_arguments = kernel_string[kernel_start:kernel_end].split(",")
     if len(kernel_arguments) != len(args):
         raise TypeError("Kernel and host argument lists do not match in size.")
     for (i, arg) in enumerate(args):

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -115,7 +115,9 @@ def check_argument_list(kernel_name, kernel_string, args):
             # We assume that if there is a possible list of arguments that matches with the provided one
             # it is the right one
             return
-    raise TypeError(collected_errors[0][0])
+    for errors in collected_errors:
+        if len(errors) > 0:
+            raise TypeError(errors[0])
 
 def check_tune_params_list(tune_params):
     """ raise an exception if a tune parameter has a forbidden name """

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -275,6 +275,37 @@ def test_check_argument_list4():
         print("Expected a TypeError to be raised")
         assert False
 
+def test_check_argument_list5():
+    kernel_string = """ //more complicated test function(because I can)
+
+        __device__ float some_lame_device_function(float *a) {
+            return a[0];
+        }
+
+        __global__ void my_test_kernel(double *a,
+                                       float *b, int c,
+                                       int d) {
+
+            a[threadIdx.x] = b[blockIdx.x]*c*d;
+        }
+        """
+    args = [numpy.array([1,2,3]).astype(numpy.float64),
+            numpy.array([1,2,3]).astype(numpy.float32),
+            numpy.int32(6), numpy.int32(7)]
+
+    #print what check_argument_list is doing as well
+    kernel_arguments = kernel_string[kernel_string.find("(") + 1:kernel_string.find(")")].split(",")
+
+    print(kernel_arguments)
+
+    try:
+        check_argument_list(kernel_string, args)
+
+    except TypeError as expected_error:
+        print("Expected no TypeError to be raised")
+        assert False
+
+
 def test_check_tune_params_list():
     tune_params = dict(zip(["one_thing", "led_to_another", "and_before_you_know_it",
                             "grid_size_y"], [1, 2, 3, 4]))

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -234,7 +234,8 @@ def test_check_argument_list1():
 
 def test_check_argument_list2():
     kernel_name = "test_kernel"
-    kernel_string = """__kernel void test_kernel(char number, double factors, int * numbers, const unsigned long * moreNumbers) {
+    kernel_string = """__kernel void test_kernel
+        (char number, double factors, int * numbers, const unsigned long * moreNumbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """
@@ -245,7 +246,7 @@ def test_check_argument_list2():
 
 def test_check_argument_list3():
     kernel_name = "test_kernel"
-    kernel_string = """__kernel void test_kernel(__global const ushort number, __global half * factors, __global long * numbers) {
+    kernel_string = """__kernel void test_kernel (__global const ushort number, __global half * factors, __global long * numbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -306,6 +306,20 @@ def test_check_argument_list5():
         print("Expected no TypeError to be raised")
         assert False
 
+def test_check_argument_list6():
+    kernel_name = "test_kernel"
+    kernel_string = """// This is where we define test_kernel
+        #define SUM(A, B) (A + B)
+        __kernel void test_kernel
+        (char number, double factors, int * numbers, const unsigned long * moreNumbers) {
+        numbers[get_global_id(0)] = SUM(numbers[get_global_id(0)] * factors[get_global_id(0)], number);
+        }
+        // /test_kernel
+        """
+    args = [numpy.byte(5), numpy.float64(4.6), numpy.int32([1, 2, 3]), numpy.uint64([3, 2, 111])]
+    check_argument_list(kernel_name, kernel_string, args)
+    #test that no exception is raised
+    assert True
 
 def test_check_tune_params_list():
     tune_params = dict(zip(["one_thing", "led_to_another", "and_before_you_know_it",

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -323,9 +323,9 @@ def test_check_argument_list6():
 
 def test_check_argument_list7():
     kernel_name = "test_kernel"
-    kernel_string = """// In this file we define test_kernel
-        #define SUM(A, B) (A + B)
-        __kernel void another_kernel (double number, double factors, int * numbers, const unsigned long * moreNumbers) 
+    kernel_string = """#define SUM(A, B) (A + B)
+        // In this file we define test_kernel
+        __kernel void another_kernel (char number, double factors, int * numbers, const unsigned long * moreNumbers) 
         __kernel void test_kernel
         (double number, double factors, int * numbers, const unsigned long * moreNumbers) {
         numbers[get_global_id(0)] = SUM(numbers[get_global_id(0)] * factors[get_global_id(0)], number);

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -321,6 +321,25 @@ def test_check_argument_list6():
     #test that no exception is raised
     assert True
 
+def test_check_argument_list7():
+    kernel_name = "test_kernel"
+    kernel_string = """// In this file we define test_kernel
+        #define SUM(A, B) (A + B)
+        __kernel void another_kernel (double number, double factors, int * numbers, const unsigned long * moreNumbers) 
+        __kernel void test_kernel
+        (double number, double factors, int * numbers, const unsigned long * moreNumbers) {
+        numbers[get_global_id(0)] = SUM(numbers[get_global_id(0)] * factors[get_global_id(0)], number);
+        }
+        // /test_kernel
+        """
+    args = [numpy.byte(5), numpy.float64(4.6), numpy.int32([1, 2, 3]), numpy.uint64([3, 2, 111])]
+    try:
+        check_argument_list(kernel_name, kernel_string, args)
+        print("Expected a TypeError to be raised.")
+        assert False
+    except TypeError as expected_error:
+        assert True
+
 def test_check_tune_params_list():
     tune_params = dict(zip(["one_thing", "led_to_another", "and_before_you_know_it",
                             "grid_size_y"], [1, 2, 3, 4]))

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -215,13 +215,14 @@ def test_get_device_interface3():
         core.DeviceInterface("", 0, 0, lang=lang)
 
 def test_check_argument_list1():
+    kernel_name = "test_kernel"
     kernel_string = """__kernel void test_kernel(int number, char * message, int * numbers) {
     numbers[get_global_id(0)] = numbers[get_global_id(0)] * number;
     }
     """
     args = [numpy.int32(5), 'blah', numpy.array([1, 2, 3])]
     try:
-        check_argument_list(kernel_string, args)
+        check_argument_list(kernel_name, kernel_string, args)
         print("Expected a TypeError to be raised")
         assert False
     except TypeError as e:
@@ -232,23 +233,25 @@ def test_check_argument_list1():
         assert False
 
 def test_check_argument_list2():
+    kernel_name = "test_kernel"
     kernel_string = """__kernel void test_kernel(char number, double factors, int * numbers, const unsigned long * moreNumbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """
     args = [numpy.byte(5), numpy.float64(4.6), numpy.int32([1, 2, 3]), numpy.uint64([3, 2, 111])]
-    check_argument_list(kernel_string, args)
+    check_argument_list(kernel_name, kernel_string, args)
     #test that no exception is raised
     assert True
 
 def test_check_argument_list3():
+    kernel_name = "test_kernel"
     kernel_string = """__kernel void test_kernel(__global const ushort number, __global half * factors, __global long * numbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """
     args = [numpy.uint16(42), numpy.float16([3, 4, 6]), numpy.int32([300])]
     try:
-        check_argument_list(kernel_string, args)
+        check_argument_list(kernel_name, kernel_string, args)
         print("Expected a TypeError to be raised")
         assert False
     except TypeError as expected_error:
@@ -259,13 +262,14 @@ def test_check_argument_list3():
         assert False
 
 def test_check_argument_list4():
+    kernel_name = "test_kernel"
     kernel_string = """__kernel void test_kernel(__global const ushort number, __global half * factors, __global long * numbers) {
         numbers[get_global_id(0)] = numbers[get_global_id(0)] * factors[get_global_id(0)] + number;
         }
         """
     args = [numpy.uint16(42), numpy.float16([3, 4, 6]), numpy.int64([300]), numpy.ubyte(32)]
     try:
-        check_argument_list(kernel_string, args)
+        check_argument_list(kernel_name, kernel_string, args)
         print("Expected a TypeError to be raised")
         assert False
     except TypeError as expected_error:
@@ -276,6 +280,7 @@ def test_check_argument_list4():
         assert False
 
 def test_check_argument_list5():
+    kernel_name = "my_test_kernel"
     kernel_string = """ //more complicated test function(because I can)
 
         __device__ float some_lame_device_function(float *a) {
@@ -299,7 +304,7 @@ def test_check_argument_list5():
     print(kernel_arguments)
 
     try:
-        check_argument_list(kernel_string, args)
+        check_argument_list(kernel_name, kernel_string, args)
 
     except TypeError as expected_error:
         print("Expected no TypeError to be raised")

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -299,11 +299,6 @@ def test_check_argument_list5():
             numpy.array([1,2,3]).astype(numpy.float32),
             numpy.int32(6), numpy.int32(7)]
 
-    #print what check_argument_list is doing as well
-    kernel_arguments = kernel_string[kernel_string.find("(") + 1:kernel_string.find(")")].split(",")
-
-    print(kernel_arguments)
-
     try:
         check_argument_list(kernel_name, kernel_string, args)
 


### PR DESCRIPTION
Old problem, new solution. This should address issue #57 although it may still not be perfect.
Fact is, parsing without building a parser is difficult. Checking for "__kernel" or "__global__" would fail with C code, and C code would need to find the returned type that is not always "void" like for OpenCL and CUDA.
So I went for a different solution. If there are multiple mentions of the kernel_name in the kernel_string, I check all of them and try to match possible parameters with the arguments provided.
In case there is a full match I simply return, as a perfect match between arguments and kernel signature should not easily happen by chance. If there are errors, I collect all of them, and then return the first one.
This can still cause issues, but only with error reporting, i.e. in case there are multiple mentions of kernel_name in kernel_string, and none of them matches the provided set of parameters, there is no guarantee that the error reported to the user is a relevant one or not.
This is a bit of a pathological case, but it may happen.
A possible solution could be to report all errors, and let the user figure out which are interesting and which are not.