### PR TITLE
Pass optimized kernel instead of naive kernel

### DIFF
--- a/tutorial/convolution.ipynb
+++ b/tutorial/convolution.ipynb
@@ -419,7 +419,7 @@
    },
    "outputs": [],
    "source": [
-    "results, env = tune_kernel(kernel_name, kernel_source, problem_size, arguments, tune_params,\n",
+    "results, env = tune_kernel(kernel_name, convolution_kernel_string, problem_size, arguments, tune_params,\n",
     "                           grid_div_x=grid_div_x, grid_div_y=grid_div_y)"
    ]
   },


### PR DESCRIPTION
The last `tune_kernel` was passing `kernel_source` (the naive kernel) instead of `convolution_kernel_string` (the optimized kernel). This raised an error since params like `filter_height` etc. weren't defined in the former.