### PR TITLE
Fix C backend output verification

### DIFF
--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -126,7 +126,7 @@ class DeviceInterface(object):
             except TypeError:
                 return verify(answer, result_host)
         else:
-            return _default_verify_function(instance, answer, result_host, atol)
+            return _default_verify_function(instance, answer, result_host, atol, verbose)
 
 
     def compile_and_benchmark(self, gpu_args, params, kernel_options, tuning_options):
@@ -275,7 +275,7 @@ class DeviceInterface(object):
 
 
 
-def _default_verify_function(instance, answer, result_host, atol):
+def _default_verify_function(instance, answer, result_host, atol, verbose):
     """default verify function based on numpy.allclose"""
 
     #first check if the length is the same
@@ -328,8 +328,8 @@ def _default_verify_function(instance, answer, result_host, atol):
             output_test = numpy.allclose(expected, result, atol=atol)
 
             if not output_test and verbose:
-                print("Error: " + util.get_config_string(params) + " detected during correctness check")
-                print("this error occured when checking value of the " + i + "th kernel argument")
+                print("Error: " + util.get_config_string(instance.params) + " detected during correctness check")
+                print("this error occured when checking value of the %oth kernel argument" % (i,))
                 print("Printing kernel output and expected result, set verbose=False to suppress this debug print")
                 numpy.set_printoptions(edgeitems=50)
                 print("Kernel output:")
@@ -340,7 +340,7 @@ def _default_verify_function(instance, answer, result_host, atol):
 
     if not correct:
         logging.debug('correctness check has found a correctness issue')
-        raise Exception("Error: " + util.get_config_string(params) + " failed correctness check")
+        raise Exception("Error: " + util.get_config_string(instance.params) + " failed correctness check")
 
     return correct
 

--- a/test/test_device_interface.py
+++ b/test/test_device_interface.py
@@ -66,14 +66,14 @@ def test_default_verify_function_arrays():
 
     for ans in [answer_type_error1, answer_type_error2, answer_type_error3]:
         try:
-            core._default_verify_function(instance, ans, result_host, 0)
+            core._default_verify_function(instance, ans, result_host, 0, False)
             print("check_kernel_output failed to throw an exception")
             assert False
         except TypeError:
             assert True
 
     for result_host in [result_host, result_host2]:
-        assert core._default_verify_function(instance, answer, result_host, 0.1)
+        assert core._default_verify_function(instance, answer, result_host, 0.1, False)
 
 
 def test_default_verify_function_scalar():
@@ -89,11 +89,11 @@ def test_default_verify_function_scalar():
 
     for ans in [answer_type_error1, answer_type_error2]:
         try:
-            core._default_verify_function(instance, ans, result_host, 0)
+            core._default_verify_function(instance, ans, result_host, 0, False)
             print("check_kernel_output failed to throw an exception")
             assert False
         except TypeError:
             assert True
 
-    assert core._default_verify_function(instance, answer, result_host, 0.1)
+    assert core._default_verify_function(instance, answer, result_host, 0.1, False)
 


### PR DESCRIPTION
This lets the C backend argument list make a copy of its data, which better matches the semantics of GPU kernels, where arguments are copied to the GPU. As a side effect, this fixes output verification of kernels with arguments that are used both for input and output.
    
The new approach stores the argument data both as a numpy object and a ctypes wrapper around the numpy object in the repurposed nameddtuple Argument. This removes the need for the arg_mapping dict.

This should fix #77.