### PR TITLE
CUDA backend measures energy consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - fix for output checking, custom verify functions are called just once
+- benchmarking returns multiple results not only time
 
 ### Added
 - support for kernels that use texture memory in CUDA
+- support for measuring energy consumption of CUDA kernels
 
 ## [0.2.0] - 2018-11-16
 ### Changed

--- a/examples/cuda/convolution.py
+++ b/examples/cuda/convolution.py
@@ -10,8 +10,8 @@ def tune():
 
     #setup tunable parameters
     tune_params = OrderedDict()
-    tune_params["filter_height"] = [i for i in range(3,35,2)]
-    tune_params["filter_width"] = [i for i in range(3,35,2)]
+    tune_params["filter_height"] = [17] #[i for i in range(3,35,2)]
+    tune_params["filter_width"] = [17] #[i for i in range(3,35,2)]
     tune_params["block_size_x"] = [16*i for i in range(1,9)]
     tune_params["block_size_y"] = [2**i for i in range(6)]
     tune_params["tile_size_x"] = [i for i in range(1,9)]
@@ -47,7 +47,7 @@ def tune():
     results, env = kernel_tuner.tune_kernel("convolution_kernel", kernel_string,
         problem_size, args, tune_params,
         grid_div_y=grid_div_y, grid_div_x=grid_div_x, cmem_args=cmem_args,
-        verbose=True, restrictions=restrict)
+        verbose=True, restrictions=restrict, iterations=100)
 
     end = time.time()
     env['execution_time'] = end-start

--- a/examples/cuda/convolution.py
+++ b/examples/cuda/convolution.py
@@ -10,8 +10,8 @@ def tune():
 
     #setup tunable parameters
     tune_params = OrderedDict()
-    tune_params["filter_height"] = [17] #[i for i in range(3,35,2)]
-    tune_params["filter_width"] = [17] #[i for i in range(3,35,2)]
+    tune_params["filter_height"] = [i for i in range(3,35,2)]
+    tune_params["filter_width"] = [i for i in range(3,35,2)]
     tune_params["block_size_x"] = [16*i for i in range(1,9)]
     tune_params["block_size_y"] = [2**i for i in range(6)]
     tune_params["tile_size_x"] = [i for i in range(1,9)]
@@ -47,7 +47,7 @@ def tune():
     results, env = kernel_tuner.tune_kernel("convolution_kernel", kernel_string,
         problem_size, args, tune_params,
         grid_div_y=grid_div_y, grid_div_x=grid_div_x, cmem_args=cmem_args,
-        verbose=True, restrictions=restrict, iterations=100)
+        verbose=True, restrictions=restrict)
 
     end = time.time()
     env['execution_time'] = end-start

--- a/examples/cuda/matmul.py
+++ b/examples/cuda/matmul.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import json
 import numpy
 import kernel_tuner
 from collections import OrderedDict
@@ -26,10 +27,14 @@ def tune():
 
     answer = [numpy.dot(A,B), None, None]
 
-    return kernel_tuner.tune_kernel("matmul_kernel", "matmul.cu",
+    res, env = kernel_tuner.tune_kernel("matmul_kernel", "matmul.cu",
         problem_size, args, tune_params,
         grid_div_y=grid_div_y, grid_div_x=grid_div_x,
-        restrictions=restrict, verbose=True, answer=answer, atol=1e-3)
+        restrictions=restrict, verbose=True, iterations=32)
+
+    with open("matmul.json", 'w') as fp:
+        json.dump(res, fp)
+
 
 if __name__ == "__main__":
     tune()

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -224,15 +224,15 @@ class DeviceInterface(object):
         if not quiet:
             print("Using: " + self.dev.name)
 
-    def benchmark(self, func, gpu_args, instance, times, verbose):
+    def benchmark(self, func, gpu_args, instance, verbose):
         """benchmark the kernel instance"""
         logging.debug('benchmark ' + instance.name)
         logging.debug('thread block dimensions x,y,z=%d,%d,%d', *instance.threads)
         logging.debug('grid dimensions x,y,z=%d,%d,%d', *instance.grid)
 
-        time = None
+        result = None
         try:
-            time = self.dev.benchmark(func, gpu_args, instance.threads, instance.grid, times)
+            result = self.dev.benchmark(func, gpu_args, instance.threads, instance.grid)
         except Exception as e:
             #some launches may fail because too many registers are required
             #to run the kernel given the current thread block size
@@ -247,7 +247,7 @@ class DeviceInterface(object):
                 logging.debug('benchmark encountered runtime failure: ' + str(e))
                 print("Error while benchmarking:", instance.name)
                 raise e
-        return time
+        return result
 
     def check_kernel_output(self, func, gpu_args, instance, answer, atol, verify, verbose):
         """runs the kernel once and checks the result against answer"""
@@ -321,7 +321,7 @@ class DeviceInterface(object):
                 self.check_kernel_output(func, gpu_args, instance, tuning_options.answer, tuning_options.atol, tuning_options.verify, verbose)
 
             #benchmark
-            time = self.benchmark(func, gpu_args, instance, tuning_options.times, verbose)
+            result = self.benchmark(func, gpu_args, instance, verbose)
 
         except Exception as e:
             #dump kernel_string to temp file
@@ -332,7 +332,7 @@ class DeviceInterface(object):
         #clean up any temporary files, if no error occured
         instance.delete_temp_files()
 
-        return time
+        return result
 
     def compile_kernel(self, instance, verbose):
         """compile the kernel for this specific instance"""

--- a/kernel_tuner/cuda.py
+++ b/kernel_tuner/cuda.py
@@ -172,9 +172,8 @@ class CudaFunctions(object):
         :param times: Return the execution time of all iterations.
         :type times: bool
 
-        :returns: All execution times, if times=True, or a robust average for the
-            kernel execution time.
-        :rtype: float
+        :returns: A dictionary with benchmark results.
+        :rtype: dict()
         """
         result = dict()
         result["times"] = []
@@ -187,7 +186,6 @@ class CudaFunctions(object):
             end.record(stream=self.stream)
             end.synchronize()
             result["times"].append(end.time_since(start))
-        result["times"] = sorted(result["times"])
         result["time"] = numpy.mean(result["times"])
         return result
 

--- a/kernel_tuner/cuda.py
+++ b/kernel_tuner/cuda.py
@@ -268,7 +268,7 @@ class CudaFunctions(object):
                 if 'normalized_coordinates' in v and v['normalized_coordinates']:
                     tex.set_flags(tex.get_flags() | drv.TRSF_NORMALIZED_COORDINATES)
 
-    def run_kernel(self, func, gpu_args, threads, grid):
+    def run_kernel(self, func, gpu_args, threads, grid, stream=None):
         """runs the CUDA kernel passed as 'func'
 
         :param func: A PyCuda kernel compiled for this specific kernel configuration
@@ -287,7 +287,7 @@ class CudaFunctions(object):
             of the grid
         :type grid: tuple(int, int)
         """
-        func(*gpu_args, block=threads, grid=grid, texrefs=self.texrefs)
+        func(*gpu_args, block=threads, grid=grid, stream=stream, texrefs=self.texrefs)
 
     def memset(self, allocation, value, size):
         """set the memory in allocation to the value in value

--- a/kernel_tuner/interface.py
+++ b/kernel_tuner/interface.py
@@ -253,8 +253,6 @@ _tuning_options = Options([
     ("iterations", ("""The number of times a kernel should be executed and
         its execution time measured when benchmarking a kernel, 7 by default.""",
         "int")),
-    ("times", ("""Returns the execution time of all iterations of a
-        kernel execution. False by default.""", "bool")),
     ("verbose", ("""Sets whether or not to report about configurations that
         were skipped during the search. This could be due to several reasons:
 
@@ -310,7 +308,7 @@ def tune_kernel(kernel_name, kernel_string, problem_size, arguments,
                 restrictions=None, answer=None, atol=1e-6, verify=None, verbose=False,
                 lang=None, device=0, platform=0, cmem_args=None, texmem_args=None,
                 num_threads=1, use_noodles=False, sample_fraction=False, compiler=None, compiler_options=None, log=None,
-                iterations=7, times=False, block_size_names=None, quiet=False, strategy=None, method=None):
+                iterations=7, block_size_names=None, quiet=False, strategy=None, method=None):
 
     if log:
         logging.basicConfig(filename=kernel_name + datetime.now().strftime('%Y%m%d-%H:%M:%S') + '.log', level=log)
@@ -409,7 +407,7 @@ def tune_kernel(kernel_name, kernel_string, problem_size, arguments,
         if results:     #checks if results is not empty
             best_config = min(results, key=lambda x: x['time'])
             units = getattr(runner, "units", None)
-            print("best performing configuration:", util.get_config_string(best_config, units=units))
+            print("best performing configuration:", util.get_config_string(best_config, list(tune_params.keys()) + ['time'], units=units))
         else:
             print("no results to report")
 

--- a/kernel_tuner/nvml.py
+++ b/kernel_tuner/nvml.py
@@ -1,0 +1,106 @@
+try:
+    import pynvml
+except ImportError:
+    pynvml = None
+
+class nvml(object):
+    """Class that gathers the NVML functionality for one device"""
+
+    def __init__(self, id=0):
+        """Create object to control device using NVML"""
+
+        pynvml.nvmlInit()
+        self.dev = pynvml.nvmlDeviceGetHandleByIndex(id)
+
+        self._pwr_limit = pynvml.nvmlDeviceGetPowerManagementLimit(self.dev)
+        self.pwr_constraints = pynvml.nvmlDeviceGetPowerManagementLimitConstraints(self.dev)
+        self._persistence_mode = pynvml.nvmlDeviceGetPersistenceMode(self.dev)
+
+        self._auto_boost = pynvml.nvmlDeviceGetAutoBoostedClocksEnabled(self.dev)[0]  # returns [isEnabled, isDefaultEnabled]
+
+        self.gr_clock_default = pynvml.nvmlDeviceGetDefaultApplicationsClock(self.dev, pynvml.NVML_CLOCK_GRAPHICS)
+        self.sm_clock_default = pynvml.nvmlDeviceGetDefaultApplicationsClock(self.dev, pynvml.NVML_CLOCK_SM)
+        self.mem_clock_default = pynvml.nvmlDeviceGetDefaultApplicationsClock(self.dev, pynvml.NVML_CLOCK_MEM)
+
+        self.supported_mem_clocks = pynvml.nvmlDeviceGetSupportedMemoryClocks(self.dev)
+
+        #gather the supported gr clocks for each supported mem clock into a dict
+        self.supported_gr_clocks = dict()
+        for mem_clock in self.supported_mem_clocks:
+            supported_gr_clocks = pynvml.nvmlDeviceGetSupportedGraphicsClocks(self.dev, mem_clock)
+            self.supported_gr_clocks[mem_clock] = supported_gr_clocks
+
+    @property
+    def pwr_state(self):
+        """Get the Device current Power State"""
+        return pynvml.nvmlDeviceGetPowerState(self.dev)
+
+    @property
+    def pwr_limit(self):
+        """Control the power limit (may require permission), check pwr_constraints for the allowed range"""
+        return self._pwr_limit
+
+    @pwr_limit.setter
+    def pwr_limit(self, new_limit):
+        if not self.pwr_constraints[0] <= new_limit <= self.pwr_constraints[1]:
+            raise ValueError("Power limit out of range")
+        pynvml.nvmlDeviceSetPowerManagementLimit(self.dev, new_limit)
+        self._pwr_limit = pynvml.nvmlDeviceGetPowerManagementLimit(self.dev)
+
+    @property
+    def persistence_mode(self):
+        """Control persistence mode (may require permission), 0 for disabled, 1 for enabled"""
+        return self._persistence_mode
+
+    @persistence_mode.setter
+    def persistence_mode(self, new_mode):
+        if not new_mode in [0, 1]:
+            raise ValueError("Illegal value for persistence mode, should be either 0 or 1")
+        pynvml.nvmlDeviceSetPersistenceMode(self.dev, new_mode)
+        self._persistence_mode = pynvml.nvmlDeviceGetPersistenceMode(self.dev)
+
+    def set_clocks(self, mem_clock, gr_clock):
+        """Set the memory and graphics clock for this device (may require permission)"""
+        if not mem_clock in self.supported_mem_clocks:
+            raise ValueError("Illegal value for memmory clock")
+        if not gr_clock in self.supported_gr_clocks[mem_clock]:
+            raise ValueError("Graphics clock incompatible with memory clock")
+        pynvml.nvmlDeviceSetApplicationsClocks(self.dev, mem_clock, gr_clock)
+        self._gr_clock = pynvml.nvmlDeviceGetApplicationsClock(self.dev, pynvml.NVML_CLOCK_GRAPHICS)
+        self._sm_clock = pynvml.nvmlDeviceGetApplicationsClock(self.dev, pynvml.NVML_CLOCK_SM)
+        self._mem_clock = pynvml.nvmlDeviceGetApplicationsClock(self.dev, pynvml.NVML_CLOCK_MEM)
+
+    @property
+    def gr_clock(self):
+        """Control the graphics clock (may require permission), only values compatible with the memory clock can be set directly"""
+        return pynvml.nvmlDeviceGetApplicationsClock(self.dev, pynvml.NVML_CLOCK_GRAPHICS)
+
+    @gr_clock.setter
+    def gr_clock(self, new_clock):
+        self.set_clocks(self.mem_clock, new_clock)
+
+    @property
+    def mem_clock(self):
+        """Control the graphics clock (may require permission), only values compatible with the graphics clock can be set directly"""
+        return pynvml.nvmlDeviceGetApplicationsClock(self.dev, pynvml.NVML_CLOCK_MEM)
+
+    @mem_clock.setter
+    def mem_clock(self, new_clock):
+        self.set_clocks(new_clock, self.gr_clock)
+
+    @property
+    def auto_boost(self):
+        """Control the auto boost setting (may require permission), 0 for disable, 1 for enabled"""
+        return self._auto_boost
+
+    @auto_boost.setter
+    def auto_boost(self, setting):
+        #might need to use pynvml.NVML_FEATURE_DISABLED or pynvml.NVML_FEATURE_ENABLED instead of 0 or 1
+        if not setting in [0, 1]:
+            raise ValueError("Illegal value for auto boost enabled, should be either 0 or 1")
+        pynvml.nvmlDeviceSetAutoBoostedClocksEnabled(self.dev, setting)
+        self._auto_boost = pynvml.nvmlDeviceGetAutoBoostedClocksEnabled(self.dev)[0]
+
+    def pwr_usage(self):
+        """Return current power usage in milliwatts"""
+        return pynvml.nvmlDeviceGetPowerUsage(self.dev)

--- a/kernel_tuner/runners/sequential.py
+++ b/kernel_tuner/runners/sequential.py
@@ -66,18 +66,27 @@ class SequentialRunner(object):
         for element in parameter_space:
             params = OrderedDict(zip(tuning_options.tune_params.keys(), element))
 
-            time = self.dev.compile_and_benchmark(self.kernel_source, self.gpu_args, params, kernel_options, tuning_options)
+            result = self.dev.compile_and_benchmark(self.kernel_source, self.gpu_args, params, kernel_options, tuning_options)
 
-            if time is None:
-                logging.debug('received time is None, kernel configuration was skipped silently due to compile or runtime failure')
+            if result is None:
+                logging.debug('received benchmark result is None, kernel configuration was skipped silently due to compile or runtime failure')
                 continue
 
             #print and append to results
+            if isinstance(result, dict):
+                time = result["time"]
+            else:
+                time = result
+
             params['time'] = time
             output_string = get_config_string(params, self.units)
             logging.debug(output_string)
             if not self.quiet:
                 print(output_string)
+
+            if isinstance(result, dict):
+                params.update(result)
+
             results.append(params)
 
         return results, self.dev.get_environment()

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -127,15 +127,18 @@ def detect_language(kernel_string):
     return lang
 
 
-def get_config_string(params, units=None):
-    """ return a compact string representation of a dictionary """
+def get_config_string(params, keys=None, units=None):
+    """ return a compact string representation of a measurement """
     compact_str_items = []
+    if not keys:
+        keys = params.keys()
     # first make a list of compact strings for each parameter
     for k, v in params.items():
-        unit = ""
-        if isinstance(units, dict): #check if not None not enough, units could be mocked which causes errors
-            unit = units.get(k, "")
-        compact_str_items.append(k + "=" + str(v) + unit)
+        if k in keys:
+            unit = ""
+            if isinstance(units, dict): #check if not None not enough, units could be mocked which causes errors
+                unit = units.get(k, "")
+            compact_str_items.append(k + "=" + str(v) + unit)
     # and finally join them
     compact_str = ", ".join(compact_str_items)
     return compact_str

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
-
+import sys
 from setuptools import setup
 
 
 def readme():
     with open('README.rst') as f:
         return f.read()
+
+if sys.version_info[0] >= 3:
+    pynvml = 'nvidia-ml-py3'
+else:
+    pynvml = 'nvidia-ml-py'
 
 
 setup(
@@ -39,7 +44,7 @@ setup(
     extras_require={
         'doc': ['sphinx', 'sphinx_rtd_theme', 'nbsphinx',
                 'noodles', 'ipython'],
-        'cuda': ['pycuda'],
+        'cuda': ['pycuda', pynvml],
         'opencl': ['pyopencl'],
         'cuda_opencl': ['pycuda', 'pyopencl'],
         'tutorial': ['jupyter', 'matplotlib', 'pandas'],

--- a/test/test_cuda_functions.py
+++ b/test/test_cuda_functions.py
@@ -63,19 +63,13 @@ def test_compile():
         print(str(e))
         assert False
 
-def dummy_func(a, b, block=0, grid=0, texrefs=None):
+def dummy_func(a, b, block=0, grid=0, stream=None, texrefs=None):
     pass
 
 @skip_if_no_cuda
 def test_benchmark():
     dev = cuda.CudaFunctions(0)
     args = [1, 2]
-    time = dev.benchmark(dummy_func, args, (1,2), (1,2), False)
-    assert time > 0
-
-@skip_if_no_cuda
-def test_benchmark_times():
-    dev = cuda.CudaFunctions(0)
-    args = [1, 2]
-    time = dev.benchmark(dummy_func, args, (1,2), (1,2), True)
-    assert len(time) == 7
+    res = dev.benchmark(dummy_func, args, (1,2), (1,2))
+    assert res["time"] > 0
+    assert len(res["times"]) == dev.iterations

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -32,7 +32,7 @@ def test_interface_calls_functions(dev_interface):
 
     expected = "#define block_size_z 1\n#define block_size_y 1\n#define block_size_x 128\n#define grid_size_z 1\n#define grid_size_y 1\n#define grid_size_x 10\n__global__ void fake_kernel(int number)"
     dev.compile.assert_called_once_with("fake_kernel", expected)
-    dev.benchmark.assert_called_once_with('compile', 'ready_argument_list', (128, 1, 1), (10, 1, 1), False)
+    dev.benchmark.assert_called_once_with('compile', 'ready_argument_list', (128, 1, 1), (10, 1, 1))
 
 @patch('kernel_tuner.core.CudaFunctions')
 def test_interface_handles_max_threads(dev_interface):
@@ -73,7 +73,7 @@ def test_interface_handles_restriction(dev_interface):
     tune_kernel("fake_kernel", kernel_string, (1,1), [numpy.int32(0)], tune_params, restrictions=restrict, lang="CUDA", verbose=True)
 
     assert dev.compile.call_count == 1
-    dev.benchmark.assert_called_once_with('compile', 'ready_argument_list', (256, 1, 1), (1, 1, 1), False)
+    dev.benchmark.assert_called_once_with('compile', 'ready_argument_list', (256, 1, 1), (1, 1, 1))
 
 @patch('kernel_tuner.core.CudaFunctions')
 def test_interface_handles_runtime_error(dev_interface):
@@ -87,7 +87,7 @@ def test_interface_handles_runtime_error(dev_interface):
     results, _ = tune_kernel("fake_kernel",kernel_string, (1,1), [numpy.int32(0)], tune_params, lang="CUDA")
 
     assert dev.compile.call_count == 1
-    dev.benchmark.assert_called_once_with('compile', 'ready_argument_list', (256, 1, 1), (1, 1, 1), False)
+    dev.benchmark.assert_called_once_with('compile', 'ready_argument_list', (256, 1, 1), (1, 1, 1))
     assert len(results) == 0
 
 @patch('kernel_tuner.core.CudaFunctions')

--- a/test/test_opencl_functions.py
+++ b/test/test_opencl_functions.py
@@ -66,15 +66,10 @@ def create_benchmark_args():
 @skip_if_no_opencl
 def test_benchmark():
     dev, args, times = create_benchmark_args()
-    time = dev.benchmark(fun_test, args, times, times, False)
-    assert time > 0
+    res = dev.benchmark(fun_test, args, times, times)
+    assert res["time"] > 0
+    assert len(res["times"]) == dev.iterations
 
-
-@skip_if_no_opencl
-def test_benchmark_times():
-    dev, args, times = create_benchmark_args()
-    time = dev.benchmark(fun_test, args, times, times, True)
-    assert len(time) == 7
 
 
 @skip_if_no_opencl


### PR DESCRIPTION
Changes the way results from benchmarks are returned and how the CUDA backend performs the benchmarks. Specifically, the CUDA backend still measures using Events, using a stream rather than the default stream, allowing parallelism between host and device. This allows the host to measure energy consumption. 
