### PR TITLE
add strategy_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - fix for output checking, custom verify functions are called just once
 - benchmarking returns multiple results not only time
 - more sophisticated implementation of genetic algorithm strategy
+- how the method to the strategy is passed, use strategy_options
 
 ### Added
 - support for kernels that use texture memory in CUDA
 - support for measuring energy consumption of CUDA kernels
+- option to set strategy_options to pass strategy specific options
 
 ## [0.2.0] - 2018-11-16
 ### Changed

--- a/README.rst
+++ b/README.rst
@@ -104,8 +104,8 @@ Optimization, the Firefly Algorithm, and Simulated Annealing.
     :align: center
 
 Using a search strategy is easy, you only need to specify to ``tune_kernel`` which strategy and method 
-you would like to use, for example ``strategy="genetic_algorithm"`` or ``strategy="basinhopping", 
-method="Powell"``. For a full overview of the supported search strategies and methods please see the `user 
+you would like to use, for example ``strategy="genetic_algorithm"`` or ``strategy="basinhopping"``. 
+For a full overview of the supported search strategies and methods please see the `user 
 api documentation <http://benvanwerkhoven.github.io/kernel_tuner/user-api.html>`__.
 
 Tuning host and kernel code

--- a/kernel_tuner/strategies/basinhopping.py
+++ b/kernel_tuner/strategies/basinhopping.py
@@ -5,6 +5,8 @@ import scipy.optimize
 
 from kernel_tuner.strategies.minimize import _cost_func, get_bounds_x0_eps, setup_method_arguments, setup_method_options
 
+supported_methods = ["Nelder-Mead", "Powell", "CG", "BFGS", "L-BFGS-B", "TNC", "COBYLA", "SLSQP"]
+
 def tune(runner, kernel_options, device_options, tuning_options):
     """ Find the best performing kernel configuration in the parameter space
 
@@ -32,7 +34,8 @@ def tune(runner, kernel_options, device_options, tuning_options):
     results = []
     cache = {}
 
-    method = tuning_options.method
+    method = tuning_options.strategy_options.get("method", "L-BFGS-B")
+    T = tuning_options.strategy_options.get("T", 1.0)
 
     #scale variables in x to make 'eps' relevant for multiple variables
     tuning_options["scaling"] = True

--- a/kernel_tuner/strategies/diff_evo.py
+++ b/kernel_tuner/strategies/diff_evo.py
@@ -5,6 +5,8 @@ from scipy.optimize import differential_evolution
 
 from kernel_tuner.strategies.minimize import get_bounds, _cost_func
 
+supported_methods = ["best1bin", "best1exp", "rand1exp", "randtobest1exp", "best2exp", "rand2exp", "randtobest1bin", "best2bin", "rand2bin", "rand1bin"]
+
 def tune(runner, kernel_options, device_options, tuning_options):
     """ Find the best performing kernel configuration in the parameter space
 
@@ -32,6 +34,8 @@ def tune(runner, kernel_options, device_options, tuning_options):
     results = []
     cache = {}
 
+    method = tuning_options.strategy_options.get("method", "best1bin")
+
     tuning_options["scaling"] = False
     #build a bounds array as needed for the optimizer
     bounds = get_bounds(tuning_options.tune_params)
@@ -40,7 +44,7 @@ def tune(runner, kernel_options, device_options, tuning_options):
 
     #call the differential evolution optimizer
     opt_result = differential_evolution(_cost_func, bounds, args, maxiter=1,
-                                        polish=False, disp=tuning_options.verbose)
+                                        polish=False, strategy=method, disp=tuning_options.verbose)
 
     if tuning_options.verbose:
         print(opt_result.message)

--- a/kernel_tuner/strategies/firefly_algorithm.py
+++ b/kernel_tuner/strategies/firefly_algorithm.py
@@ -40,13 +40,13 @@ def tune(runner, kernel_options, device_options, tuning_options):
 
     args = (kernel_options, tuning_options, runner, results, cache)
 
-    num_particles = 20
-    maxiter = 100
+    num_particles = tuning_options.strategy_options.get("popsize", 20)
+    maxiter = tuning_options.strategy_options.get("maxiter", 100)
 
     #parameters needed by the Firefly Algorithm
-    B0 = 1.0
-    gamma = 1.0
-    alpha = 0.20
+    B0 = tuning_options.strategy_options.get("B0", 1.0)
+    gamma = tuning_options.strategy_options.get("gamma", 1.0)
+    alpha = tuning_options.strategy_options.get("alpha", 0.2)
 
     best_time_global = 1e20
     best_position_global = []

--- a/kernel_tuner/strategies/genetic_algorithm.py
+++ b/kernel_tuner/strategies/genetic_algorithm.py
@@ -31,13 +31,12 @@ def tune(runner, kernel_options, device_options, tuning_options):
     """
 
     dna_size = len(tuning_options.tune_params.keys())
-    pop_size = 20
-    generations = 100
 
-    #crossover = single_point_crossover
-    #crossover = two_point_crossover
-    crossover = uniform_crossover
-    #crossover = disruptive_uniform_crossover
+    options = tuning_options.strategy_options
+    pop_size = options.get("popsize", 20)
+    generations = options.get("maxiter", 100)
+    crossover = supported_methods[options.get("method", "uniform")]
+    mutation_chance = options.get("mutation_chance", 10)
 
     tuning_options["scaling"] = False
     tune_params = tuning_options.tune_params
@@ -77,8 +76,8 @@ def tune(runner, kernel_options, device_options, tuning_options):
 
             dna1, dna2 = crossover(dna1, dna2)
 
-            population.append(mutate(dna1, tune_params))
-            population.append(mutate(dna2, tune_params))
+            population.append(mutate(dna1, tune_params, mutation_chance))
+            population.append(mutate(dna2, tune_params, mutation_chance))
 
     return all_results, runner.dev.get_environment()
 
@@ -146,10 +145,9 @@ def random_val(index, tune_params):
     key = list(tune_params.keys())[index]
     return random.choice(tune_params[key])
 
-def mutate(dna, tune_params):
+def mutate(dna, tune_params, mutation_chance):
     """Mutate DNA with 1/mutation_chance chance"""
     dna_out = []
-    mutation_chance = 10
     for i in range(len(dna)):
         if int(random.random()*mutation_chance) == 1:
             dna_out.append(random_val(i, tune_params))
@@ -205,4 +203,9 @@ def disruptive_uniform_crossover(dna1, dna2):
                     swaps += 1
     return (child1, child2)
 
+
+supported_methods = {"single_point": single_point_crossover,
+                     "two_point": two_point_crossover,
+                     "uniform": uniform_crossover,
+                     "disruptive_uniform": disruptive_uniform_crossover}
 

--- a/kernel_tuner/strategies/pso.py
+++ b/kernel_tuner/strategies/pso.py
@@ -42,8 +42,8 @@ def tune(runner, kernel_options, device_options, tuning_options):
 
     args = (kernel_options, tuning_options, runner, results, cache)
 
-    num_particles = 20
-    maxiter = 100
+    num_particles = tuning_options.strategy_options.get("popsize", 20)
+    maxiter = tuning_options.strategy_options.get("maxiter", 100)
 
     best_time_global = 1e20
     best_position_global = []

--- a/kernel_tuner/strategies/random_sample.py
+++ b/kernel_tuner/strategies/random_sample.py
@@ -32,6 +32,8 @@ def tune(runner, kernel_options, device_options, tuning_options):
 
     tune_params = tuning_options.tune_params
 
+    fraction = tuning_options.strategy_options.get("fraction", 0.1)
+
     #compute cartesian product of all tunable parameters
     parameter_space = itertools.product(*tune_params.values())
 
@@ -45,7 +47,7 @@ def tune(runner, kernel_options, device_options, tuning_options):
     #reduce parameter space to a random sample using sample_fraction
     parameter_space = numpy.array(list(parameter_space))
     size = len(parameter_space)
-    fraction = int(numpy.ceil(size * float(tuning_options.sample_fraction)))
+    fraction = int(numpy.ceil(size * fraction))
     sample_indices = numpy.random.choice(range(size), size=fraction, replace=False)
     parameter_space = parameter_space[sample_indices]
 

--- a/test/strategies/test_genetic_algorithm.py
+++ b/test/strategies/test_genetic_algorithm.py
@@ -51,7 +51,7 @@ def test_random_val():
 def test_mutate():
     pop = ga.random_population(1, tune_params)
 
-    mutant = ga.mutate(pop[0], tune_params)
+    mutant = ga.mutate(pop[0], tune_params, 10)
     assert len(pop[0]) == len(mutant)
     assert mutant[0] in tune_params["x"]
     assert mutant[1] in tune_params["y"]
@@ -59,10 +59,7 @@ def test_mutate():
 def test_crossover_functions():
     dna1 = ["x", "y", "z"]
     dna2 = ["a", "b", "c"]
-    funcs = [ga.single_point_crossover,
-             ga.two_point_crossover,
-             ga.uniform_crossover,
-             ga.disruptive_uniform_crossover]
+    funcs = ga.supported_methods.values()
     for func in funcs:
         children = func(dna1, dna2)
         print(dna1, dna2)

--- a/test/strategies/test_minimize.py
+++ b/test/strategies/test_minimize.py
@@ -29,7 +29,7 @@ def test__cost_func():
 
     x = [1, 4]
     kernel_options = None
-    tuning_options = Options(scaling=False, tune_params=tune_params, restrictions=None)
+    tuning_options = Options(scaling=False, tune_params=tune_params, restrictions=None, strategy_options={})
     runner = fake_runner()
     results = []
     cache = {}
@@ -48,6 +48,7 @@ def test__cost_func():
     tuning_options = Options(scaling=False,
                              tune_params=tune_params,
                              restrictions=restrictions,
+                             strategy_options={},
                              verbose=True)
     time = minimize._cost_func(x, kernel_options, tuning_options, runner, results, cache)
     assert time == 1e20
@@ -59,10 +60,11 @@ def test_setup_method_arguments():
 
 
 def test_setup_method_options():
-    tuning_options = Options(eps=1e-5,tune_params=tune_params)
+    tuning_options = Options(eps=1e-5, tune_params=tune_params, strategy_options={}, verbose=True)
 
     method_options = minimize.setup_method_options("L-BFGS-B", tuning_options)
     assert isinstance(method_options, dict)
     assert method_options["eps"] == 1e-5
-    assert method_options["maxfun"] == 9
+    assert method_options["maxfun"] == 100
+    assert method_options["disp"] == True
 

--- a/test/test_runners.py
+++ b/test/test_runners.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import numpy as np
+import pytest
 
 import kernel_tuner
 from kernel_tuner import core
@@ -8,32 +9,8 @@ from kernel_tuner.interface import Options
 
 from .context import skip_if_no_cuda, skip_if_no_noodles
 
-
-def test_random_sample():
-
-    kernel_string = "float test_kernel(float *a) { return 1.0f; }"
-    a = np.arange(4, dtype=np.float32)
-
-    tune_params = {"block_size_x": range(1, 25)}
-    print(tune_params)
-
-    result, _ = kernel_tuner.tune_kernel(
-        "test_kernel", kernel_string, (1, 1), [a], tune_params, sample_fraction=0.1)
-
-    print(result)
-
-    # check that number of benchmarked kernels is 10% (rounded up)
-    assert len(result) == 3
-
-    # check all returned results make sense
-    for v in result:
-        assert v['time'] == 1.0
-
-
-@skip_if_no_noodles
-@skip_if_no_cuda
-def test_noodles_runner():
-
+@pytest.fixture
+def env():
     kernel_string = """
     __global__ void vector_add(float *c, float *a, float *b, int n) {
         int i = blockIdx.x * block_size_x + threadIdx.x;
@@ -52,46 +29,52 @@ def test_noodles_runner():
     args = [c, a, b, n]
     tune_params = {"block_size_x": [128+64*i for i in range(15)]}
 
+    return ["vector_add", kernel_string, size, args, tune_params]
+
+
+def test_random_sample():
+
+    kernel_string = "float test_kernel(float *a) { return 1.0f; }"
+    a = np.arange(4, dtype=np.float32)
+
+    tune_params = {"block_size_x": range(1, 25)}
+    print(tune_params)
+
     result, _ = kernel_tuner.tune_kernel(
-        "vector_add", kernel_string, size, args, tune_params,
-        use_noodles=True, num_threads=4)
+        "test_kernel", kernel_string, (1, 1), [a], tune_params,
+        strategy="random_sample", strategy_options={"fraction": 0.1})
 
-    assert len(result) == len(tune_params["block_size_x"])
+    print(result)
+
+    # check that number of benchmarked kernels is 10% (rounded up)
+    assert len(result) == 3
+
+    # check all returned results make sense
+    for v in result:
+        assert v['time'] == 1.0
 
 
-def get_vector_add_args():
-    size = int(1e6)
-    a = np.random.randn(size).astype(np.float32)
-    b = np.random.randn(size).astype(np.float32)
-    c = np.zeros_like(b).astype(np.float32)
-    n = np.int32(size)
-    return c, a, b, n
+@skip_if_no_noodles
+@skip_if_no_cuda
+def test_noodles_runner(env):
+    result, _ = kernel_tuner.tune_kernel(*env, use_noodles=True, num_threads=4)
+    assert len(result) == len(env[-1]["block_size_x"])
 
 
 @skip_if_no_cuda
-def test_diff_evo():
+def test_diff_evo(env):
+    result, _ = kernel_tuner.tune_kernel(*env, strategy="diff_evo", verbose=True)
+    assert len(result) > 0
 
-    kernel_string = """
-    __global__ void vector_add(float *c, float *a, float *b, int n) {
-        int i = blockIdx.x * block_size_x + threadIdx.x;
-        if (i<n) {
-            c[i] = a[i] + b[i];
-        }
-    } """
-
-    args = get_vector_add_args()
-    tune_params = {"block_size_x": [128+64*i for i in range(5)]}
-
-    result, _ = kernel_tuner.tune_kernel(
-        "vector_add", kernel_string, args[-1], args, tune_params,
-        method="diff_evo", verbose=True)
-
-    print(result)
+@skip_if_no_cuda
+def test_genetic_algorithm(env):
+    options = dict(method="uniform", popsize=10, maxiter=2, mutation_change=1)
+    result, _ = kernel_tuner.tune_kernel(*env, strategy="genetic_algorithm", strategy_options=options, verbose=True)
     assert len(result) > 0
 
 
 @skip_if_no_cuda
-def test_sequential_runner_alt_block_size_names():
+def test_sequential_runner_alt_block_size_names(env):
 
     kernel_string = """__global__ void vector_add(float *c, float *a, float *b, int n) {
         int i = blockIdx.x * block_dim_x + threadIdx.x;
@@ -101,20 +84,20 @@ def test_sequential_runner_alt_block_size_names():
     }
     """
 
-    c, a, b, n = get_vector_add_args()
-    args = [c, a, b, n]
     tune_params = {"block_dim_x": [128 + 64 * i for i in range(5)],
                    "block_size_y": [1], "block_size_z": [1]}
 
-    ref = (a+b).astype(np.float32)
+    env[1] = kernel_string
+    env[-1] = tune_params
+
+    ref = (env[3][1]+env[3][2]).astype(np.float32)
     answer = [ref, None, None, None]
 
     block_size_names = ["block_dim_x"]
 
-    result, _ = kernel_tuner.tune_kernel(
-        "vector_add", kernel_string, int(n), args,
-        tune_params, grid_div_x=["block_dim_x"], answer=answer,
-        block_size_names=block_size_names)
+    result, _ = kernel_tuner.tune_kernel(*env,
+                                         grid_div_x=["block_dim_x"], answer=answer,
+                                         block_size_names=block_size_names)
 
     assert len(result) == len(tune_params["block_dim_x"])
 


### PR DESCRIPTION
As mentioned in issue #83 this pull request adds the optional argument to tune_kernel to pass a dictionary with strategy specific options. This pull request also removes 2 optional arguments from tune_kernel, namely method and sample_fraction, which should now be passed within the strategy_options dict. 

This pull request also improves the code in tune_kernel, making the strategies responsible for specifying which methods they support. This simplifies the code in tune_kernel quite a bit.