### PR TITLE
better support for partial loop unrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+- support loop unrolling using params that start with loop_unroll_factor
+- always insert "define kernel_tuner" to allow preprocessor ifdef kernel_tuner
 
 ## [0.3.1] - 2020-06-11
 ### Added

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -67,6 +67,7 @@ Reduction
 [`CUDA <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/cuda/reduction.py>`__] [`OpenCL <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/opencl/reduction.py>`__]
  - use vector types and shuffle instructions (shuffle is only available in CUDA)
  - tune the number of thread blocks the kernel is executed with
+ - tune the partial loop unrolling factor of a for-loop
  - tune pipeline that consists of two kernels
  - tune with custom output verification function
 

--- a/examples/cuda/reduction.cu
+++ b/examples/cuda/reduction.cu
@@ -1,5 +1,3 @@
-#include <stdio.h>
-
 #ifndef vector
 #define vector 1
 #endif 
@@ -18,7 +16,6 @@
 #define stop_loop 0
 #endif
 
-
 __global__ void sum_floats(float *sum_global, floatvector *array, int n) {
     int ti = threadIdx.x;
     int x = blockIdx.x * block_size_x + threadIdx.x;
@@ -26,6 +23,7 @@ __global__ void sum_floats(float *sum_global, floatvector *array, int n) {
     float sum = 0.0f;
 
     //cooperatively iterate over input array with all thread blocks
+    #pragma unroll loop_unroll_factor_0
     for (int i=x; i<n/vector; i+=step_size) {
         floatvector v = array[i];
         #if vector == 1
@@ -56,7 +54,7 @@ __global__ void sum_floats(float *sum_global, floatvector *array, int n) {
         sum = sh_mem[ti];
         #pragma unroll
         for (unsigned int s=16; s>0; s>>=1) {
-            sum += __shfl_down(sum, s);        
+            sum += __shfl_down_sync(0, sum, s);
         }
     }
     #else

--- a/examples/cuda/reduction.py
+++ b/examples/cuda/reduction.py
@@ -14,6 +14,7 @@ def tune():
     tune_params["use_shuffle"] = [0, 1]
     tune_params["vector"] = [2**i for i in range(3)]
     tune_params["num_blocks"] = [2**i for i in range(5,16)]
+    tune_params["loop_unroll_factor_0"] = [0, 1, 8, 16, 32, 64]
 
     problem_size = "num_blocks"
     size = 800000000

--- a/examples/opencl/reduction.cl
+++ b/examples/opencl/reduction.cl
@@ -17,15 +17,9 @@ __kernel void sum_floats(__global float *sum_global, __global floatvector *array
     float sum = 0.0f;
 
     //cooperatively iterate over input array with all thread blocks
+    #pragma unroll loop_unroll_factor
     for (int i=x; i<n/vector; i+=step_size) {
-        floatvector v = array[i];
-        #if vector == 1
-        sum += v;
-        #elif vector == 2
-        sum += v.x + v.y;
-        #elif vector == 4
-        sum += v.x + v.y + v.z + v.w;
-        #endif
+        sum += dot(array[i], (floatvector)(1));
     }
     
     //reduce sum to single value (or last 32 in case of use_shuffle)

--- a/examples/opencl/reduction.py
+++ b/examples/opencl/reduction.py
@@ -13,9 +13,10 @@ def tune():
     tune_params["block_size_x"] = [2**i for i in range(5,11)]
     tune_params["vector"] = [2**i for i in range(3)]
     tune_params["num_blocks"] = [2**i for i in range(5,11)]
+    tune_params["loop_unroll_factor"] = [0, 1, 8, 16, 32]
 
     problem_size = "num_blocks"
-    size = 80000000
+    size = 800000000
     max_blocks = max(tune_params["num_blocks"])
 
     x = numpy.random.rand(size).astype(numpy.float32)
@@ -27,7 +28,7 @@ def tune():
     #prepare output verification with custom function
     reference = [numpy.sum(x), None, None]
     def verify_partial_reduce(cpu_result, gpu_result, atol=None):
-        return numpy.isclose(cpu_result, numpy.sum(gpu_result), atol=atol)
+        return numpy.isclose(cpu_result[0], numpy.sum(gpu_result[0]), atol=atol)
 
     #tune the first kernel
     first_kernel, _ = tune_kernel("sum_floats", kernel_string, problem_size,

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -115,7 +115,7 @@ class KernelSource(object):
 
             ks = self.get_kernel_string(i, params)
             # add preprocessor statements
-            n, ks = util.prepare_kernel_string(kernel_name, ks, params, grid, threads, block_size_names)
+            n, ks = util.prepare_kernel_string(kernel_name, ks, params, grid, threads, block_size_names, self.lang)
 
             if i == 0:
                 # primary kernel source

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -126,8 +126,9 @@ def test_prepare_kernel_string():
     params = dict()
     params["is"] = 8
 
-    _, output = prepare_kernel_string("this", kernel, params, (3,7), (1,2,3), block_size_names)
-    expected = "#define is 8\n" \
+    _, output = prepare_kernel_string("this", kernel, params, (3,7), (1,2,3), block_size_names, "")
+    expected = "#define kernel_tuner 1\n" \
+               "#define is 8\n" \
                "#define block_size_z 3\n" \
                "#define block_size_y 2\n" \
                "#define block_size_x 1\n" \


### PR DESCRIPTION
This pull request adds support for partial loop unrolling. 

For OpenCL you could already do this using ``#pragma unroll any_name`` together with a tunable parameter that is inserted by Kernel Tuner as ``#define any_name X``. 

But for CUDA the compiler does not support defining the partial loop unrolling factor using another C preprocessor define. It is required to set this value using a "constant integer expression" for example ``const int name = X;``. So to enable easy auto-tuning of partial loop unrolling factors
in Kernel Tuner I've added some functionality for inserting any tunable parameter that start with ``loop_unroll_factor`` using ``const int loop_unroll_factor<name> = <value>;`` instead of ``#define loop_unroll_factor<name> <value>``.

Interestingly, OpenCL seems to support the syntax ``#pragma unroll 0``, whereas CUDA gives an error saying the unroll factor can't be 0. OpenCL interprets a factor of 0 as 'complete' or 'let the compiler figure it out' unrolling. So to enable this as well for CUDA the tuner now refrains from inserting loop_unroll_factor<name> and even removes the ``#pragma unroll loop_unroll_factor<name>`` from the code. Note that both OpenCL and CUDA interpret a factor of 1 as disabling loop unrolling for this loop.

The use of the new partial loop unrolling feature is demonstrated in the reduction examples for both CUDA and OpenCL.

This feature introduces the principle of the tuner making small modifications to the kernel code to better facilitate tuning and simplify writing tunable code. It's important to keep in mind one of the key design goals of Kernel Tuner, which is allowing the tuned kernels to be used by regular compilers and not insert Kernel Tuner as a dependency in the kernels. I think we can facilitate this by adding another function to the user interface that reproduces any code instrumentations that would otherwise be done at compile time by the tuner.

It is also another use case of tunable parameters with special names, which shows the need to clearly document a vocabulary of all the reserved or special tunable parameter names.