### PR TITLE
Vector add using Jinja template

### DIFF
--- a/examples/cuda/vector_add_jinja.cu
+++ b/examples/cuda/vector_add_jinja.cu
@@ -1,8 +1,5 @@
-#include <helper_math.h>
 
-extern "C"
-{
-__global__ void vector_add(const {{ real_type }} * a,const {{ real_type }} * b, {{ real_type }} * c, int size)
+__global__ void vector_add(const {{ real_type }} * __restrict__ a, const {{ real_type }} * __restrict__ b, {{ real_type }} * __restrict__ c, int size)
 {
     int index = (blockIdx.x * {{ block_size_x }} * {{ tiling_x }}) + threadIdx.x;
 
@@ -10,8 +7,16 @@ __global__ void vector_add(const {{ real_type }} * a,const {{ real_type }} * b, 
     {% set offset = block_size_x * tile %}
     if ( index + {{ offset }} < (size / {{ vector_size }}) )
     {
-        c[index + {{ offset }}] = a[index + {{ offset }}] + b[index + {{ offset }}];
+        {{ real_type }} item_a = a[index + {{ offset }}];
+        {{ real_type }} item_b = b[index + {{ offset }}];
+
+        {% if vector_size == 1 %}
+        c[index + {{ offset }}] =  item_a + item_b;
+        {% elif vector_size == 2 %}
+        c[index + {{ offset }}] =  make_{{ real_type }}(item_a.x + item_b.x, item_a.y + item_b.y);
+        {% elif vector_size == 4 %}
+        c[index + {{ offset }}] =  make_{{ real_type }}(item_a.x + item_b.x, item_a.y + item_b.y, item_a.z + item_b.z, item_a.w + item_b.w);
+        {% endif %}
     }
     {% endfor %}
-}
 }

--- a/examples/cuda/vector_add_jinja.cu
+++ b/examples/cuda/vector_add_jinja.cu
@@ -1,8 +1,13 @@
-__global__ void vector_add(const {{ real_type }}{{ vector_size }} * a,const {{ real_type }}{{ vector_size }} * b, {{ real_type }}{{ vector_size }} * c, int size)
+#include <helper_math.h>
+
+extern "C"
+{
+__global__ void vector_add(const {{ real_type }} * a,const {{ real_type }} * b, {{ real_type }} * c, int size)
 {
     int i = (blockIdx.x * block_size_x) + threadIdx.x;
-    if ( i < size )
+    if ( i < (size / {{ vector_size }}) )
     {
         c[i] = a[i] + b[i];
     }
+}
 }

--- a/examples/cuda/vector_add_jinja.cu
+++ b/examples/cuda/vector_add_jinja.cu
@@ -4,13 +4,13 @@ extern "C"
 {
 __global__ void vector_add(const {{ real_type }} * a,const {{ real_type }} * b, {{ real_type }} * c, int size)
 {
-    int i = (blockIdx.x * block_size_x) + threadIdx.x;
+    int index = (blockIdx.x * {{ block_size_x }} * {{ tiling_x }}) + threadIdx.x;
 
     {% for tile in range(tiling_x) %}
     {% set offset = block_size_x * tile %}
-    if ( i + {{ offset }} < (size / {{ vector_size }}) )
+    if ( index + {{ offset }} < (size / {{ vector_size }}) )
     {
-        c[i + {{ offset }}] = a[i + {{ offset }}] + b[i + {{ offset }}];
+        c[index + {{ offset }}] = a[index + {{ offset }}] + b[index + {{ offset }}];
     }
     {% endfor %}
 }

--- a/examples/cuda/vector_add_jinja.cu
+++ b/examples/cuda/vector_add_jinja.cu
@@ -1,0 +1,8 @@
+__global__ void vector_add(const {{ real_type }}{{ vector_size }} * a,const {{ real_type }}{{ vector_size }} * b, {{ real_type }}{{ vector_size }} * c, int size)
+{
+    int i = (blockIdx.x * block_size_x) + threadIdx.x;
+    if ( i < size )
+    {
+        c[i] = a[i] + b[i];
+    }
+}

--- a/examples/cuda/vector_add_jinja.cu
+++ b/examples/cuda/vector_add_jinja.cu
@@ -5,9 +5,13 @@ extern "C"
 __global__ void vector_add(const {{ real_type }} * a,const {{ real_type }} * b, {{ real_type }} * c, int size)
 {
     int i = (blockIdx.x * block_size_x) + threadIdx.x;
-    if ( i < (size / {{ vector_size }}) )
+
+    {% for tile in range(tiling_x) %}
+    {% set offset = block_size_x * tile %}
+    if ( i + {{ offset }} < (size / {{ vector_size }}) )
     {
-        c[i] = a[i] + b[i];
+        c[i + {{ offset }}] = a[i + {{ offset }}] + b[i + {{ offset }}];
     }
+    {% endfor %}
 }
 }

--- a/examples/cuda/vector_add_jinja.py
+++ b/examples/cuda/vector_add_jinja.py
@@ -14,7 +14,7 @@ def generate_code(tuning_parameters):
         real_type = tuning_parameters["real_type"]
     else:
         real_type = str(tuning_parameters["real_type"]) + str(tuning_parameters["vector_size"])
-    return template.render(real_type=real_type, vector_size=tuning_parameters["vector_size"], tiling_x=tuning_parameters["tiling_x"])
+    return template.render(real_type=real_type, vector_size=tuning_parameters["vector_size"], block_size_x=tuning_parameters["block_size_x"], tiling_x=tuning_parameters["tiling_x"])
 
 
 def tune():
@@ -32,7 +32,6 @@ def tune():
     tuning_parameters["block_size_x"] = [32 * i for i in range(1, 33)]
     tuning_parameters["vector_size"] = [1, 2, 4]
     tuning_parameters["tiling_x"] = [i for i in range(1, 33)]
-    constraints = list()
 
     result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters, lang="CUDA", grid_div_x=["block_size_x * vector_size * tiling_x"])
 

--- a/examples/cuda/vector_add_jinja.py
+++ b/examples/cuda/vector_add_jinja.py
@@ -11,10 +11,10 @@ def generate_code(tuning_parameters):
     template_environment = Environment(loader=template_loader)
     template = template_environment.get_template("vector_add_jinja.cu")
     if tuning_parameters["vector_size"] == 1:
-        vector_size = ""
+        real_type = tuning_parameters["real_type"]
     else:
-        vector_size = str(tuning_parameters["vector_size"])
-    return template.render(real_type=tuning_parameters["real_type"], vector_size=vector_size)
+        real_type = str(tuning_parameters["real_type"]) + str(tuning_parameters["vector_size"])
+    return template.render(real_type=real_type, vector_size=tuning_parameters["vector_size"])
 
 
 def tune():
@@ -30,9 +30,9 @@ def tune():
     tuning_parameters = dict()
     tuning_parameters["real_type"] = ["float"]
     tuning_parameters["block_size_x"] = [32 * i for i in range(1, 33)]
-    tuning_parameters["vector_size"] = [1]
+    tuning_parameters["vector_size"] = [1, 2, 4]
 
-    result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters, lang="CUDA")
+    result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters, lang="CUDA", grid_div_x=["block_size_x / vector_size"])
 
     with open("vector_add_jinja.json", 'w') as fp:
         json.dump(result, fp)

--- a/examples/cuda/vector_add_jinja.py
+++ b/examples/cuda/vector_add_jinja.py
@@ -1,4 +1,6 @@
-"""Minimal example of vector_add using a Jinja2 template"""
+"""
+Minimal example of vector_add using a Jinja2 template.
+"""
 
 from kernel_tuner import tune_kernel
 from jinja2 import Environment, FileSystemLoader
@@ -25,7 +27,8 @@ def tune():
     c = numpy.zeros_like(b)
     n = numpy.int32(size)
 
-    args = [a, b, c, n]
+    arguments = [a, b, c, n]
+    control = [None, None, a + b, None]
 
     tuning_parameters = dict()
     tuning_parameters["real_type"] = ["float"]
@@ -33,7 +36,7 @@ def tune():
     tuning_parameters["vector_size"] = [1, 2, 4]
     tuning_parameters["tiling_x"] = [i for i in range(1, 33)]
 
-    result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters, lang="CUDA", grid_div_x=["block_size_x * vector_size * tiling_x"])
+    result = tune_kernel("vector_add", generate_code, size, arguments, tuning_parameters, lang="CUDA", grid_div_x=["block_size_x * vector_size * tiling_x"], answer=control)
 
     with open("vector_add_jinja.json", 'w') as fp:
         json.dump(result, fp)

--- a/examples/cuda/vector_add_jinja.py
+++ b/examples/cuda/vector_add_jinja.py
@@ -14,7 +14,7 @@ def generate_code(tuning_parameters):
         real_type = tuning_parameters["real_type"]
     else:
         real_type = str(tuning_parameters["real_type"]) + str(tuning_parameters["vector_size"])
-    return template.render(real_type=real_type, vector_size=tuning_parameters["vector_size"])
+    return template.render(real_type=real_type, vector_size=tuning_parameters["vector_size"], tiling_x=tuning_parameters["tiling_x"])
 
 
 def tune():
@@ -31,8 +31,10 @@ def tune():
     tuning_parameters["real_type"] = ["float"]
     tuning_parameters["block_size_x"] = [32 * i for i in range(1, 33)]
     tuning_parameters["vector_size"] = [1, 2, 4]
+    tuning_parameters["tiling_x"] = [i for i in range(1, 33)]
+    constraints = list()
 
-    result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters, lang="CUDA", grid_div_x=["block_size_x / vector_size"])
+    result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters, lang="CUDA", grid_div_x=["block_size_x * vector_size * tiling_x"])
 
     with open("vector_add_jinja.json", 'w') as fp:
         json.dump(result, fp)

--- a/examples/cuda/vector_add_jinja.py
+++ b/examples/cuda/vector_add_jinja.py
@@ -28,10 +28,11 @@ def tune():
     args = [a, b, c, n]
 
     tuning_parameters = dict()
-    tuning_parameters["real_type"] = "float"
+    tuning_parameters["real_type"] = ["float"]
     tuning_parameters["block_size_x"] = [32 * i for i in range(1, 33)]
+    tuning_parameters["vector_size"] = [1]
 
-    result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters)
+    result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters, lang="CUDA")
 
     with open("vector_add_jinja.json", 'w') as fp:
         json.dump(result, fp)

--- a/examples/cuda/vector_add_jinja.py
+++ b/examples/cuda/vector_add_jinja.py
@@ -1,0 +1,43 @@
+"""Minimal example of vector_add using a Jinja2 template"""
+
+from kernel_tuner import tune_kernel
+from jinja2 import Environment, FileSystemLoader
+import json
+import numpy
+
+
+def generate_code(tuning_parameters):
+    template_loader = FileSystemLoader(".")
+    template_environment = Environment(loader=template_loader)
+    template = template_environment.get_template("vector_add_jinja.cu")
+    if tuning_parameters["vector_size"] == 1:
+        vector_size = ""
+    else:
+        vector_size = str(tuning_parameters["vector_size"])
+    return template.render(real_type=tuning_parameters["real_type"], vector_size=vector_size)
+
+
+def tune():
+    size = 10000000
+
+    a = numpy.random.randn(size).astype(numpy.float32)
+    b = numpy.random.randn(size).astype(numpy.float32)
+    c = numpy.zeros_like(b)
+    n = numpy.int32(size)
+
+    args = [a, b, c, n]
+
+    tuning_parameters = dict()
+    tuning_parameters["real_type"] = "float"
+    tuning_parameters["block_size_x"] = [32 * i for i in range(1, 33)]
+
+    result = tune_kernel("vector_add", generate_code, size, args, tuning_parameters)
+
+    with open("vector_add_jinja.json", 'w') as fp:
+        json.dump(result, fp)
+
+    return result
+
+
+if __name__ == "__main__":
+    tune()


### PR DESCRIPTION
Contributing an example of using kernel_tuner with a CUDA code generator that is based on the Jinja template engine. The code has few tunable parameters and has been tested on a NVIDIA Titan X Pascal on the DAS.