### PR TITLE
Turn device interfaces and runner into Python Context Managers

### DIFF
--- a/kernel_tuner/c.py
+++ b/kernel_tuner/c.py
@@ -73,6 +73,12 @@ class CFunctions(object):
         self.env = env
         self.name = platform.processor()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
     def ready_argument_list(self, arguments):
         """ready argument list to be passed to the C function
 

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -224,6 +224,11 @@ class DeviceInterface(object):
         if not quiet:
             print("Using: " + self.dev.name)
 
+        dev.__enter__()
+
+    def __enter__(self):
+        return self
+
     def benchmark(self, func, gpu_args, instance, verbose):
         """benchmark the kernel instance"""
         logging.debug('benchmark ' + instance.name)
@@ -426,9 +431,9 @@ class DeviceInterface(object):
         return True
 
 
-    def __del__(self):
+    def __exit__(self, *exc):
         if hasattr(self, 'dev'):
-            del self.dev
+            self.dev.__exit__(*exc)
 
 
 

--- a/kernel_tuner/cuda.py
+++ b/kernel_tuner/cuda.py
@@ -91,7 +91,10 @@ class CudaFunctions(object):
         self.env = env
         self.name = env["device_name"]
 
-    def __del__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
         for gpu_mem in self.allocations:
             if hasattr(gpu_mem, 'free'): #if needed for when using mocks during testing
                 gpu_mem.free()

--- a/kernel_tuner/interface.py
+++ b/kernel_tuner/interface.py
@@ -452,39 +452,37 @@ def tune_kernel(kernel_name, kernel_string, problem_size, arguments,
         strategy = brute_force
 
 
-    runner = SequentialRunner(kernel_source, kernel_options, device_options, iterations)
+    with SequentialRunner(kernel_source, kernel_options, device_options, iterations) as runner:
 
-    #the user-specified function may or may not have an optional atol argument;
-    #we normalize it so that it always accepts atol.
-    tuning_options.verify = util.normalize_verify_function(tuning_options.verify)
+        #the user-specified function may or may not have an optional atol argument;
+        #we normalize it so that it always accepts atol.
+        tuning_options.verify = util.normalize_verify_function(tuning_options.verify)
 
-    #process cache
-    if cache:
-        if cache[-5:] != ".json":
-            cache += ".json"
+        #process cache
+        if cache:
+            if cache[-5:] != ".json":
+                cache += ".json"
 
-        util.process_cache(cache, kernel_options, tuning_options, runner)
-    else:
-        tuning_options.cache = {}
-        tuning_options.cachefile = None
-
-    #call the strategy to execute the tuning process
-    results, env = strategy.tune(runner, kernel_options, device_options, tuning_options)
-
-    #finished iterating over search space
-    if not device_options.quiet:
-        if results:     #checks if results is not empty
-            best_config = min(results, key=lambda x: x['time'])
-            units = getattr(runner, "units", None)
-            print("best performing configuration:")
-            util.print_config_output(tune_params, best_config, device_options.quiet, metrics, units)
+            util.process_cache(cache, kernel_options, tuning_options, runner)
         else:
-            print("no results to report")
+            tuning_options.cache = {}
+            tuning_options.cachefile = None
 
-    if cache:
-        util.close_cache(cache)
+        #call the strategy to execute the tuning process
+        results, env = strategy.tune(runner, kernel_options, device_options, tuning_options)
 
-    del runner.dev
+        #finished iterating over search space
+        if not device_options.quiet:
+            if results:     #checks if results is not empty
+                best_config = min(results, key=lambda x: x['time'])
+                units = getattr(runner, "units", None)
+                print("best performing configuration:")
+                util.print_config_output(tune_params, best_config, device_options.quiet, metrics, units)
+            else:
+                print("no results to report")
+
+        if cache:
+            util.close_cache(cache)
 
     return results, env
 
@@ -539,52 +537,49 @@ def run_kernel(kernel_name, kernel_string, problem_size, arguments,
     device_options = Options([(k, opts[k]) for k in _device_options.keys()])
 
     #detect language and create the right device function interface
-    dev = core.DeviceInterface(kernel_source, iterations=1, **device_options)
+    with core.DeviceInterface(kernel_source, iterations=1, **device_options) as dev:
 
-    #move data to the GPU
-    gpu_args = dev.ready_argument_list(arguments)
+        #move data to the GPU
+        gpu_args = dev.ready_argument_list(arguments)
 
-    instance = None
-    try:
-        #create kernel instance
-        instance = dev.create_kernel_instance(kernel_source, kernel_options, params, False)
-        if instance is None:
-            raise Exception("cannot create kernel instance, too many threads per block")
+        instance = None
+        try:
+            #create kernel instance
+            instance = dev.create_kernel_instance(kernel_source, kernel_options, params, False)
+            if instance is None:
+                raise Exception("cannot create kernel instance, too many threads per block")
 
-        # see if the kernel arguments have correct type
-        util.check_argument_list(instance.name, instance.kernel_string, arguments)
+            # see if the kernel arguments have correct type
+            util.check_argument_list(instance.name, instance.kernel_string, arguments)
 
-        #compile the kernel
-        func = dev.compile_kernel(instance, False)
-        if func is None:
-            raise Exception("cannot compile kernel, too much shared memory used")
+            #compile the kernel
+            func = dev.compile_kernel(instance, False)
+            if func is None:
+                raise Exception("cannot compile kernel, too much shared memory used")
 
-        #add constant memory arguments to compiled module
-        if cmem_args is not None:
-            dev.copy_constant_memory_args(cmem_args)
-        #add texture memory arguments to compiled module
-        if texmem_args is not None:
-            dev.copy_texture_memory_args(texmem_args)
-    finally:
-        #delete temp files
-        if instance is not None:
-            instance.delete_temp_files()
+            #add constant memory arguments to compiled module
+            if cmem_args is not None:
+                dev.copy_constant_memory_args(cmem_args)
+            #add texture memory arguments to compiled module
+            if texmem_args is not None:
+                dev.copy_texture_memory_args(texmem_args)
+        finally:
+            #delete temp files
+            if instance is not None:
+                instance.delete_temp_files()
 
-    #run the kernel
-    if not dev.run_kernel(func, gpu_args, instance):
-        raise Exception("runtime error occured, too many resources requested")
+        #run the kernel
+        if not dev.run_kernel(func, gpu_args, instance):
+            raise Exception("runtime error occured, too many resources requested")
 
-    #copy data in GPU memory back to the host
-    results = []
-    for i, arg in enumerate(arguments):
-        if numpy.isscalar(arg):
-            results.append(arg)
-        else:
-            results.append(numpy.zeros_like(arg))
-            dev.memcpy_dtoh(results[-1], gpu_args[i])
-
-    #trying to make run_kernel work nicely with the Nvidia Visual Profiler
-    del dev
+        #copy data in GPU memory back to the host
+        results = []
+        for i, arg in enumerate(arguments):
+            if numpy.isscalar(arg):
+                results.append(arg)
+            else:
+                results.append(numpy.zeros_like(arg))
+                dev.memcpy_dtoh(results[-1], gpu_args[i])
 
     return results
 

--- a/kernel_tuner/opencl.py
+++ b/kernel_tuner/opencl.py
@@ -49,6 +49,12 @@ class OpenCLFunctions(object):
         self.env = env
         self.name = dev.name
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
     def ready_argument_list(self, arguments):
         """ready argument list to be passed to the kernel, allocates gpu mem
 

--- a/kernel_tuner/runners/sequential.py
+++ b/kernel_tuner/runners/sequential.py
@@ -30,7 +30,8 @@ class SequentialRunner(object):
         """
 
         #detect language and create high-level device interface
-        self.dev = DeviceInterface(kernel_source, iterations=iterations, **device_options)
+        self.dev = DeviceInterface(kernel_source, iterations=iterations, **device_options).__enter__()
+
         self.units = self.dev.units
         self.quiet = device_options.quiet
         self.kernel_source = kernel_source
@@ -39,6 +40,10 @@ class SequentialRunner(object):
 
         #move data to the GPU
         self.gpu_args = self.dev.ready_argument_list(kernel_options.arguments)
+
+
+    def __enter__(self):
+        return self
 
 
     def run(self, parameter_space, kernel_options, tuning_options):
@@ -110,9 +115,9 @@ class SequentialRunner(object):
         return results, self.dev.get_environment()
 
 
-    def __del__(self):
+    def __exit__(self, *exc):
         if hasattr(self, 'dev'):
-            del self.dev
+            self.dev.__exit__(*exc)
 
 
 

--- a/test/test_c_functions.py
+++ b/test/test_c_functions.py
@@ -24,9 +24,8 @@ def test_ready_argument_list1():
     arg3 = np.array([7, 8, 9]).astype(np.int32)
     arguments = [arg1, arg2, arg3]
 
-    cfunc = CFunctions()
-
-    output = cfunc.ready_argument_list(arguments)
+    with CFunctions() as cfunc:
+        output = cfunc.ready_argument_list(arguments)
     print(output)
 
     output_arg1 = np.ctypeslib.as_array(output[0].ctypes, shape=arg1.shape)
@@ -56,8 +55,8 @@ def test_ready_argument_list2():
     arg3 = np.float32(6.0)
     arguments = [arg1, arg2, arg3]
 
-    cfunc = CFunctions()
-    output = cfunc.ready_argument_list(arguments)
+    with CFunctions() as cfunc:
+        output = cfunc.ready_argument_list(arguments)
     print(output)
 
     output_arg1 = np.ctypeslib.as_array(output[0].ctypes, shape=arg1.shape)
@@ -74,27 +73,27 @@ def test_ready_argument_list2():
 def test_ready_argument_list3():
     arg1 = Mock()
     arguments = [arg1]
-    cfunc = CFunctions()
-    try:
-        cfunc.ready_argument_list(arguments)
-        assert False
-    except Exception:
-        assert True
+    with CFunctions() as cfunc:
+        try:
+            cfunc.ready_argument_list(arguments)
+            assert False
+        except Exception:
+            assert True
 
 
 def test_ready_argument_list4():
     with raises(TypeError):
         arg1 = int(9)
-        cfunc = CFunctions()
-        cfunc.ready_argument_list([arg1])
+        with CFunctions() as cfunc:
+            cfunc.ready_argument_list([arg1])
 
 
 def test_ready_argument_list5():
     arg1 = np.array([1, 2, 3]).astype(np.float32)
     arguments = [arg1]
 
-    cfunc = CFunctions()
-    output = cfunc.ready_argument_list(arguments)
+    with CFunctions() as cfunc:
+        output = cfunc.ready_argument_list(arguments)
 
     assert all(output[0].numpy == arg1)
 
@@ -106,21 +105,21 @@ def test_ready_argument_list5():
 def test_byte_array_arguments():
     arg1 = np.array([1, 2, 3]).astype(np.int8)
 
-    cfunc = CFunctions()
+    with CFunctions() as cfunc:
 
-    output = cfunc.ready_argument_list([arg1])
+        output = cfunc.ready_argument_list([arg1])
 
-    output_arg1 = np.ctypeslib.as_array(output[0].ctypes, shape=arg1.shape)
+        output_arg1 = np.ctypeslib.as_array(output[0].ctypes, shape=arg1.shape)
 
-    assert output_arg1.dtype == 'int8'
+        assert output_arg1.dtype == 'int8'
 
-    assert all(output_arg1 == arg1)
+        assert all(output_arg1 == arg1)
 
-    dest = np.zeros_like(arg1)
+        dest = np.zeros_like(arg1)
 
-    cfunc.memcpy_dtoh(dest, output[0])
+        cfunc.memcpy_dtoh(dest, output[0])
 
-    assert all(dest == arg1)
+        assert all(dest == arg1)
 
 
 @patch('kernel_tuner.c.subprocess')
@@ -132,9 +131,8 @@ def test_compile(npct, subprocess):
     kernel_sources = KernelSource(kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
-    cfunc = CFunctions()
-
-    f = cfunc.compile(kernel_instance)
+    with CFunctions() as cfunc:
+        f = cfunc.compile(kernel_instance)
 
     print(subprocess.mock_calls)
     print(npct.mock_calls)
@@ -163,9 +161,8 @@ def test_compile_detects_device_code(npct, subprocess):
     kernel_sources = KernelSource(kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
-    cfunc = CFunctions()
-
-    cfunc.compile(kernel_instance)
+    with CFunctions() as cfunc:
+        cfunc.compile(kernel_instance)
 
     print(subprocess.check_call.call_args_list)
 
@@ -188,8 +185,8 @@ def test_memset():
     x_c = x.ctypes.data_as(C.POINTER(C.c_float))
     arg = Argument(numpy=x, ctypes=x_c)
 
-    cfunc = CFunctions()
-    cfunc.memset(arg, 0, x.nbytes)
+    with CFunctions() as cfunc:
+       cfunc.memset(arg, 0, x.nbytes)
 
     output = np.ctypeslib.as_array(x_c, shape=(4,))
 
@@ -205,8 +202,8 @@ def test_memcpy_dtoh():
     arg = Argument(numpy=x, ctypes=x_c)
     output = np.zeros_like(x)
 
-    cfunc = CFunctions()
-    cfunc.memcpy_dtoh(output, arg)
+    with CFunctions() as cfunc:
+        cfunc.memcpy_dtoh(output, arg)
 
     print(a)
     print(output)
@@ -222,8 +219,8 @@ def test_memcpy_htod():
     x_c = x.ctypes.data_as(C.POINTER(C.c_float))
     arg = Argument(numpy=x, ctypes=x_c)
 
-    cfunc = CFunctions()
-    cfunc.memcpy_htod(arg, src)
+    with CFunctions() as cfunc:
+        cfunc.memcpy_htod(arg, src)
 
     assert all(arg.numpy == a)
 
@@ -242,10 +239,10 @@ def test_complies_fortran_function_no_module():
     kernel_sources = KernelSource(kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
-    cfunc = CFunctions(compiler="gfortran")
-    func = cfunc.compile(kernel_instance)
+    with CFunctions(compiler="gfortran") as cfunc:
+        func = cfunc.compile(kernel_instance)
 
-    result = cfunc.run_kernel(func, [], (), ())
+        result = cfunc.run_kernel(func, [], (), ())
 
     assert np.isclose(result, 42.0)
 
@@ -271,10 +268,10 @@ def test_complies_fortran_function_with_module():
     kernel_sources = KernelSource(kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
-    cfunc = CFunctions(compiler="gfortran")
-    func = cfunc.compile(kernel_instance)
+    with CFunctions(compiler="gfortran") as cfunc:
+        func = cfunc.compile(kernel_instance)
 
-    result = cfunc.run_kernel(func, [], (), ())
+        result = cfunc.run_kernel(func, [], (), ())
 
     assert np.isclose(result, 42.0)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -42,10 +42,10 @@ def env():
                              arguments=args, lang=lang, grid_div_x=None, grid_div_y=None, grid_div_z=None,
                              cmem_args=None, texmem_args=None, block_size_names=None)
     device_options = Options(device=0, platform=0, quiet=False, compiler=None, compiler_options=None)
-    dev = core.DeviceInterface(kernel_source, iterations=7, **device_options)
-    instance = dev.create_kernel_instance(kernel_source, kernel_options, params, verbose)
+    with core.DeviceInterface(kernel_source, iterations=7, **device_options) as dev:
+        instance = dev.create_kernel_instance(kernel_source, kernel_options, params, verbose)
 
-    return dev, instance
+        yield dev, instance
 
 
 @skip_if_no_cuda
@@ -62,7 +62,6 @@ def test_default_verify_function(env):
     answer = [args[1] + args[2]]
     try:
         core._default_verify_function(instance, answer, args, 1e-6, verbose)
-        # dev.check_kernel_output(func, gpu_args, instance, answer, 1e-6, None, verbose)
         print("Expected a TypeError to be raised")
         assert False
     except TypeError as expected_error:

--- a/test/test_cuda_functions.py
+++ b/test/test_cuda_functions.py
@@ -21,12 +21,12 @@ def test_ready_argument_list():
 
     arguments = [c, a, b]
 
-    dev = cuda.CudaFunctions(0)
-    gpu_args = dev.ready_argument_list(arguments)
+    with cuda.CudaFunctions(0) as dev:
+        gpu_args = dev.ready_argument_list(arguments)
 
-    assert isinstance(gpu_args[0], pycuda.driver.DeviceAllocation)
-    assert isinstance(gpu_args[1], np.int32)
-    assert isinstance(gpu_args[2], pycuda.driver.DeviceAllocation)
+        assert isinstance(gpu_args[0], pycuda.driver.DeviceAllocation)
+        assert isinstance(gpu_args[1], np.int32)
+        assert isinstance(gpu_args[2], pycuda.driver.DeviceAllocation)
 
 
 @skip_if_no_cuda
@@ -43,11 +43,11 @@ def test_compile():
 
     kernel_sources = KernelSource(kernel_string, "cuda")
     kernel_instance = KernelInstance("vector_add", kernel_sources, kernel_string, [], None, None, dict(), [])
-    dev = cuda.CudaFunctions(0)
-    try:
-        dev.compile(kernel_instance)
-    except Exception as e:
-        pytest.fail("Did not expect any exception:" + str(e))
+    with cuda.CudaFunctions(0) as dev:
+        try:
+            dev.compile(kernel_instance)
+        except Exception as e:
+            pytest.fail("Did not expect any exception:" + str(e))
 
 
 def dummy_func(a, b, block=0, grid=0, stream=None, shared=0, texrefs=None):
@@ -56,8 +56,8 @@ def dummy_func(a, b, block=0, grid=0, stream=None, shared=0, texrefs=None):
 
 @skip_if_no_cuda
 def test_benchmark():
-    dev = cuda.CudaFunctions(0)
-    args = [1, 2]
-    res = dev.benchmark(dummy_func, args, (1, 2), (1, 2))
-    assert res["time"] > 0
-    assert len(res["times"]) == dev.iterations
+    with cuda.CudaFunctions(0) as dev:
+        args = [1, 2]
+        res = dev.benchmark(dummy_func, args, (1, 2), (1, 2))
+        assert res["time"] > 0
+        assert len(res["times"]) == dev.iterations

--- a/test/test_cuda_mocked.py
+++ b/test/test_cuda_mocked.py
@@ -32,8 +32,8 @@ def test_ready_argument_list(drv, *args):
     b = np.random.randn(size).astype(np.float32)
     arguments = [a, b]
 
-    dev = cuda.CudaFunctions(0)
-    gpu_args = dev.ready_argument_list(arguments)
+    with cuda.CudaFunctions(0) as dev:
+        gpu_args = dev.ready_argument_list(arguments)
 
     print(drv.mock_calls)
     print(gpu_args)
@@ -51,25 +51,25 @@ def test_compile(drv, *args):
 
     # setup mocked stuff
     drv = setup_mock(drv)
-    dev = cuda.CudaFunctions(0)
-    dev.source_mod = Mock()
-    dev.source_mod.return_value.get_function.return_value = 'func'
+    with cuda.CudaFunctions(0) as dev:
+        dev.source_mod = Mock()
+        dev.source_mod.return_value.get_function.return_value = 'func'
 
-    # call compile
-    kernel_string = "__global__ void vector_add()"
-    kernel_sources = KernelSource(kernel_string, "cuda")
-    kernel_instance = KernelInstance("vector_add", kernel_sources, kernel_string, [], None, None, dict(), [])
-    func = dev.compile(kernel_instance)
+        # call compile
+        kernel_string = "__global__ void vector_add()"
+        kernel_sources = KernelSource(kernel_string, "cuda")
+        kernel_instance = KernelInstance("vector_add", kernel_sources, kernel_string, [], None, None, dict(), [])
+        func = dev.compile(kernel_instance)
 
-    # verify behavior
-    assert dev.source_mod.call_count == 1
-    assert dev.current_module is dev.source_mod.return_value
-    assert func == 'func'
+        # verify behavior
+        assert dev.source_mod.call_count == 1
+        assert dev.current_module is dev.source_mod.return_value
+        assert func == 'func'
 
-    assert kernel_string == list(dev.source_mod.mock_calls[0])[1][0]
-    optional_args = list(dev.source_mod.mock_calls[0])[2]
-    assert optional_args['code'] == 'sm_55'
-    assert optional_args['arch'] == 'compute_55'
+        assert kernel_string == list(dev.source_mod.mock_calls[0])[1][0]
+        optional_args = list(dev.source_mod.mock_calls[0])[2]
+        assert optional_args['code'] == 'sm_55'
+        assert optional_args['arch'] == 'compute_55'
 
 
 def dummy_func(a, b, block=0, grid=0, shared=0, stream=None, texrefs=None):
@@ -84,14 +84,14 @@ def test_benchmark(drv, *args):
 
     drv.Event.return_value.time_since.return_value = 0.1
 
-    dev = cuda.CudaFunctions(0)
-    res = dev.benchmark(dummy_func, [1, 2], (1, 2), (1, 2))
-    assert res["time"] > 0
+    with cuda.CudaFunctions(0) as dev:
+        res = dev.benchmark(dummy_func, [1, 2], (1, 2), (1, 2))
+        assert res["time"] > 0
 
-    assert dev.context.synchronize.call_count == 1
-    assert drv.Event.return_value.synchronize.call_count == dev.iterations
-    assert drv.Event.return_value.record.call_count == 2*dev.iterations
-    assert drv.Event.return_value.time_since.call_count == dev.iterations
+        assert dev.context.synchronize.call_count == 1
+        assert drv.Event.return_value.synchronize.call_count == dev.iterations
+        assert drv.Event.return_value.record.call_count == 2*dev.iterations
+        assert drv.Event.return_value.time_since.call_count == dev.iterations
 
 
 @patch('kernel_tuner.cuda.nvml')
@@ -103,14 +103,14 @@ def test_copy_constant_memory_args(drv, *args):
     fake_array = np.zeros(10).astype(np.float32)
     cmem_args = {'fake_array': fake_array}
 
-    dev = cuda.CudaFunctions(0)
-    dev.current_module = Mock()
-    dev.current_module.get_global.return_value = ['get_global']
+    with cuda.CudaFunctions(0) as dev:
+        dev.current_module = Mock()
+        dev.current_module.get_global.return_value = ['get_global']
 
-    dev.copy_constant_memory_args(cmem_args)
+        dev.copy_constant_memory_args(cmem_args)
 
-    drv.memcpy_htod.assert_called_once_with('get_global', fake_array)
-    dev.current_module.get_global.assert_called_once_with('fake_array')
+        drv.memcpy_htod.assert_called_once_with('get_global', fake_array)
+        dev.current_module.get_global.assert_called_once_with('fake_array')
 
 
 @patch('kernel_tuner.cuda.nvml')
@@ -124,20 +124,20 @@ def test_copy_texture_memory_args(drv, *args):
 
     texref = Mock()
 
-    dev = cuda.CudaFunctions(0)
-    dev.current_module = Mock()
-    dev.current_module.get_texref.return_value = texref
+    with cuda.CudaFunctions(0) as dev:
+        dev.current_module = Mock()
+        dev.current_module.get_texref.return_value = texref
 
-    dev.copy_texture_memory_args(texmem_args)
+        dev.copy_texture_memory_args(texmem_args)
 
-    drv.matrix_to_texref.assert_called_once_with(fake_array, texref, order="C")
-    dev.current_module.get_texref.assert_called_once_with('fake_tex')
+        drv.matrix_to_texref.assert_called_once_with(fake_array, texref, order="C")
+        dev.current_module.get_texref.assert_called_once_with('fake_tex')
 
-    texmem_args = {'fake_tex2': {'array': fake_array, 'filter_mode': 'linear', 'address_mode': ['border', 'clamp']}}
+        texmem_args = {'fake_tex2': {'array': fake_array, 'filter_mode': 'linear', 'address_mode': ['border', 'clamp']}}
 
-    dev.copy_texture_memory_args(texmem_args)
-    drv.matrix_to_texref.assert_called_with(fake_array, texref, order="C")
-    dev.current_module.get_texref.assert_called_with('fake_tex2')
-    texref.set_filter_mode.assert_called_once_with(drv.filter_mode.LINEAR)
-    texref.set_address_mode.assert_any_call(0, drv.address_mode.BORDER)
-    texref.set_address_mode.assert_any_call(1, drv.address_mode.CLAMP)
+        dev.copy_texture_memory_args(texmem_args)
+        drv.matrix_to_texref.assert_called_with(fake_array, texref, order="C")
+        dev.current_module.get_texref.assert_called_with('fake_tex2')
+        texref.set_filter_mode.assert_called_once_with(drv.filter_mode.LINEAR)
+        texref.set_address_mode.assert_any_call(0, drv.address_mode.BORDER)
+        texref.set_address_mode.assert_any_call(1, drv.address_mode.CLAMP)

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -211,23 +211,24 @@ def test_detect_language3():
 @skip_if_no_cuda
 def test_get_device_interface1():
     lang = "CUDA"
-    dev = core.DeviceInterface(core.KernelSource("", lang=lang))
-    assert isinstance(dev, core.DeviceInterface)
-    assert isinstance(dev.dev, cuda.CudaFunctions)
+    with core.DeviceInterface(core.KernelSource("", lang=lang)) as dev:
+        assert isinstance(dev, core.DeviceInterface)
+        assert isinstance(dev.dev, cuda.CudaFunctions)
 
 
 @skip_if_no_opencl
 def test_get_device_interface2():
     lang = "OpenCL"
-    dev = core.DeviceInterface(core.KernelSource("", lang=lang))
-    assert isinstance(dev, core.DeviceInterface)
-    assert isinstance(dev.dev, opencl.OpenCLFunctions)
+    with core.DeviceInterface(core.KernelSource("", lang=lang)) as dev:
+        assert isinstance(dev, core.DeviceInterface)
+        assert isinstance(dev.dev, opencl.OpenCLFunctions)
 
 
 def test_get_device_interface3():
     with raises(Exception):
         lang = "blabla"
-        core.DeviceInterface(lang)
+        with core.DeviceInterface(lang) as dev:
+            pass
 
 
 def assert_user_warning(f, args, substring=None):


### PR DESCRIPTION
This makes the closing of the device context independent of the
behaviour of the garbage collector. Specifically for a CUDA device, the
garbage collector could delay closing the context until a new context
had already been created, causing unpredictable crashes.

NB: The DeviceInterface, CudaFunctions and SequentialRunner classes no
longer implicitly close their contexts in their destructor, but only in the
__exit__ method now.