### PR TITLE
first version of cupy backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - option to control measurements using observers
 - support for NVML tunable parameters
 - option to simulate auto-tuning searches from existing cache files
+- Cupy backend to support C++ templated CUDA kernels
 
 ## [0.3.2] - 2020-11-04
 ### Added

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -12,7 +12,7 @@ Below we list the example applications and the features they illustrate.
 
 Vector Add
 ----------
-[`CUDA <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/cuda/vector_add.py>`__] [`OpenCL <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/opencl/vector_add.py>`__] [`C <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/c/vector_add.py>`__] [`Fortran <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/fortran/vector_add.py>`__]
+[`CUDA <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/cuda/vector_add.py>`__] [`CUDA-C++ <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/cuda-c++/vector_add.py>`__] [`OpenCL <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/opencl/vector_add.py>`__] [`C <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/c/vector_add.py>`__] [`Fortran <https://github.com/benvanwerkhoven/kernel_tuner/blob/master/examples/fortran/vector_add.py>`__]
  - use Kernel Tuner to tune a simple kernel
 
 Stencil

--- a/examples/cuda-c++/vector_add.py
+++ b/examples/cuda-c++/vector_add.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""This is the minimal example from the README converted to C++11"""
+
+import numpy
+from kernel_tuner import tune_kernel
+
+kernel_string = """
+template<typename T>
+__global__ void vector_add(T *c, T *a, T *b, int n) {
+    auto i = blockIdx.x * block_size_x + threadIdx.x;
+    if (i<n) {
+        c[i] = a[i] + b[i];
+    }
+}
+
+"""
+
+size = 10000000
+
+a = numpy.random.randn(size).astype(numpy.float32)
+b = numpy.random.randn(size).astype(numpy.float32)
+c = numpy.zeros_like(b)
+n = numpy.int32(size)
+
+args = [c, a, b, n]
+
+tune_params = dict()
+tune_params["block_size_x"] = [128+64*i for i in range(15)]
+
+tune_kernel("vector_add<float>", kernel_string, size, args, tune_params)

--- a/examples/cuda/vector_add_cupy.py
+++ b/examples/cuda/vector_add_cupy.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+"""This is the minimal example from the README"""
+
+import json
+
+import numpy
+import cupy as cp
+from kernel_tuner import tune_kernel
+
+def tune():
+
+    kernel_string = """
+    __global__ void vector_add(float *c, float *a, float *b, int n) {
+        int i = blockIdx.x * block_size_x + threadIdx.x;
+        if (i<n) {
+            c[i] = a[i] + b[i];
+        }
+    }
+    """
+
+    size = 10000000
+
+    a = cp.random.randn(size).astype(cp.float32)
+    b = cp.random.randn(size).astype(cp.float32)
+    c = cp.zeros_like(b)
+    n = numpy.int32(size)
+
+    args = [c, a, b, n]
+
+    tune_params = dict()
+    tune_params["block_size_x"] = [128+64*i for i in range(15)]
+
+    answer = [a+b, None, None, None]
+
+    result = tune_kernel("vector_add", kernel_string, size, args, tune_params, answer=answer, verbose=True, lang="Cupy")
+
+    with open("vector_add.json", 'w') as fp:
+        json.dump(result, fp)
+
+    return result
+
+
+if __name__ == "__main__":
+    tune()

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -8,7 +8,7 @@ import numpy as np
 
 try:
     import cupy as cp
-except:
+except ImportError:
     cp = np
 
 from kernel_tuner.cupy import CupyFunctions
@@ -303,9 +303,8 @@ class DeviceInterface(object):
         #re-copy original contents of output arguments to GPU memory, to overwrite any changes
         #by earlier kernel runs
         for i, arg in enumerate(instance.arguments):
-            if verify or answer[i] is not None:
-                if isinstance(arg, (np.ndarray, cp.ndarray)):
-                    self.dev.memcpy_htod(gpu_args[i], arg)
+            if verify or answer[i] is not None and isinstance(arg, (np.ndarray, cp.ndarray)):
+                self.dev.memcpy_htod(gpu_args[i], arg)
 
         #run the kernel
         check = self.run_kernel(func, gpu_args, instance)

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -4,8 +4,14 @@ from __future__ import print_function
 from collections import namedtuple
 import resource
 import logging
-import numpy
+import numpy as np
 
+try:
+    import cupy as cp
+except:
+    cp = np
+
+from kernel_tuner.cupy import CupyFunctions
 from kernel_tuner.cuda import CudaFunctions
 from kernel_tuner.opencl import OpenCLFunctions
 from kernel_tuner.c import CFunctions
@@ -42,10 +48,11 @@ class KernelSource(object):
     must be filenames.
     """
 
-    def __init__(self, kernel_sources, lang):
+    def __init__(self, kernel_name, kernel_sources, lang):
         if not isinstance(kernel_sources, list):
             kernel_sources = [kernel_sources]
         self.kernel_sources = kernel_sources
+        self.kernel_name = kernel_name
         if lang is None:
             if callable(self.kernel_sources[0]):
                 raise TypeError("Please specify language when using a code generator function")
@@ -213,8 +220,14 @@ class DeviceInterface(object):
 
         logging.debug('DeviceInterface instantiated, lang=%s', lang)
 
+        #if there is a template specification in the kernel name switch to cupy backend
+        if lang == "CUDA" and "<" in kernel_source.kernel_name:
+            lang = "CUPY"
+
         if lang == "CUDA":
             dev = CudaFunctions(device, compiler_options=compiler_options, iterations=iterations, observers=observers)
+        elif lang.upper() == "CUPY":
+            dev = CupyFunctions(device, compiler_options=compiler_options, iterations=iterations, observers=observers)
         elif lang == "OpenCL":
             dev = OpenCLFunctions(device, platform, compiler_options=compiler_options, iterations=iterations, observers=observers)
         elif lang == "C":
@@ -291,7 +304,7 @@ class DeviceInterface(object):
         #by earlier kernel runs
         for i, arg in enumerate(instance.arguments):
             if verify or answer[i] is not None:
-                if isinstance(arg, numpy.ndarray):
+                if isinstance(arg, (np.ndarray, cp.ndarray)):
                     self.dev.memcpy_htod(gpu_args[i], arg)
 
         #run the kernel
@@ -302,8 +315,8 @@ class DeviceInterface(object):
         #retrieve gpu results to host memory
         result_host = []
         for i, arg in enumerate(instance.arguments):
-            if (verify or answer[i] is not None) and isinstance(arg, numpy.ndarray):
-                result_host.append(numpy.zeros_like(arg))
+            if (verify or answer[i] is not None) and isinstance(arg, (np.ndarray, cp.ndarray)):
+                result_host.append(np.zeros_like(arg))
                 self.dev.memcpy_dtoh(result_host[-1], gpu_args[i])
             else:
                 result_host.append(None)
@@ -415,7 +428,7 @@ class DeviceInterface(object):
 
         #setup thread block and grid dimensions
         threads, grid = util.setup_block_and_grid(kernel_options.problem_size, grid_div, params, kernel_options.block_size_names)
-        if numpy.prod(threads) > self.dev.max_threads:
+        if np.prod(threads) > self.dev.max_threads:
             if verbose:
                 print("skipping config", instance_string, "reason: too many threads per block")
             return None
@@ -462,7 +475,7 @@ class DeviceInterface(object):
 
 
 def _default_verify_function(instance, answer, result_host, atol, verbose):
-    """default verify function based on numpy.allclose"""
+    """default verify function based on np.allclose"""
 
     #first check if the length is the same
     if len(instance.arguments) != len(answer):
@@ -470,20 +483,20 @@ def _default_verify_function(instance, answer, result_host, atol, verbose):
     #for each element in the argument list, check if the types match
     for i, arg in enumerate(instance.arguments):
         if answer[i] is not None:    #skip None elements in the answer list
-            if isinstance(answer[i], numpy.ndarray) and isinstance(arg, numpy.ndarray):
+            if isinstance(answer[i], (np.ndarray, cp.ndarray)) and isinstance(arg, (np.ndarray, cp.ndarray)):
                 if answer[i].dtype != arg.dtype:
                     raise TypeError("Element " + str(i) + " of the expected results list is not of the same dtype as the kernel output: " +
                                     str(answer[i].dtype) + " != " + str(arg.dtype) + ".")
                 if answer[i].size != arg.size:
                     raise TypeError("Element " + str(i) + " of the expected results list has a size different from " + "the kernel argument: " +
                                     str(answer[i].size) + " != " + str(arg.size) + ".")
-            elif isinstance(answer[i], numpy.number) and isinstance(arg, numpy.number):
+            elif isinstance(answer[i], np.number) and isinstance(arg, np.number):
                 if answer[i].dtype != arg.dtype:
                     raise TypeError("Element " + str(i) + " of the expected results list is not the same as the kernel output: " + str(answer[i].dtype) +
                                     " != " + str(arg.dtype) + ".")
             else:
                 #either answer[i] and argument have different types or answer[i] is not a numpy type
-                if not isinstance(answer[i], numpy.ndarray) or not isinstance(answer[i], numpy.number):
+                if not isinstance(answer[i], np.ndarray) or not isinstance(answer[i], np.number):
                     raise TypeError("Element " + str(i) + " of expected results list is not a numpy array or numpy scalar.")
                 else:
                     raise TypeError("Element " + str(i) + " of expected results list and kernel arguments have different types.")
@@ -505,13 +518,16 @@ def _default_verify_function(instance, answer, result_host, atol, verbose):
 
             result = _ravel(result_host[i])
             expected = _flatten(expected)
-            output_test = numpy.allclose(expected, result, atol=atol)
+            if any([isinstance(array, cp.ndarray) for array in [expected, result]]):
+                output_test = cp.allclose(expected, result, atol=atol)
+            else:
+                output_test = np.allclose(expected, result, atol=atol)
 
             if not output_test and verbose:
                 print("Error: " + util.get_config_string(instance.params) + " detected during correctness check")
                 print("this error occured when checking value of the %oth kernel argument" % (i, ))
                 print("Printing kernel output and expected result, set verbose=False to suppress this debug print")
-                numpy.set_printoptions(edgeitems=50)
+                np.set_printoptions(edgeitems=50)
                 print("Kernel output:")
                 print(result)
                 print("Expected:")

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -220,10 +220,6 @@ class DeviceInterface(object):
 
         logging.debug('DeviceInterface instantiated, lang=%s', lang)
 
-        #if there is a template specification in the kernel name switch to cupy backend
-        if lang == "CUDA" and "<" in kernel_source.kernel_name:
-            lang = "CUPY"
-
         if lang == "CUDA":
             dev = CudaFunctions(device, compiler_options=compiler_options, iterations=iterations, observers=observers)
         elif lang.upper() == "CUPY":

--- a/kernel_tuner/cupy.py
+++ b/kernel_tuner/cupy.py
@@ -59,8 +59,7 @@ class CupyFunctions(object):
             raise ImportError("Error: cupy not installed, please install e.g. using 'pip install cupy-cuda111', please check https://github.com/cupy/cupy.")
 
         #select device
-        self.dev = dev = cp.cuda.Device(device)
-        dev.use()
+        self.dev = dev = cp.cuda.Device(device).__enter__()
 
         #inspect device properties
         self.devprops = dev.attributes
@@ -103,7 +102,8 @@ class CupyFunctions(object):
         return self
 
     def __exit__(self, *exc):
-        pass
+        """destroy the device context"""
+        self.dev.__exit__()
 
     def ready_argument_list(self, arguments):
         """ready argument list to be passed to the kernel, allocates gpu mem

--- a/kernel_tuner/cupy.py
+++ b/kernel_tuner/cupy.py
@@ -1,0 +1,393 @@
+"""This module contains all Cupy specific kernel_tuner functions"""
+from __future__ import print_function
+
+import re
+
+import logging
+import time
+import numpy as np
+
+from kernel_tuner.observers import BenchmarkObserver
+from kernel_tuner.nvml import nvml
+
+#embedded in try block to be able to generate documentation
+#and run tests without cupy installed
+try:
+    import cupy as cp
+except ImportError:
+    cp = None
+
+
+class CupyRuntimeObserver(BenchmarkObserver):
+    """ Observer that measures time using CUDA events during benchmarking """
+    def __init__(self, dev):
+        self.dev = dev
+        self.stream = dev.stream
+        self.start = dev.start
+        self.end = dev.end
+        self.times = []
+
+    def after_finish(self):
+        self.times.append(cp.cuda.get_elapsed_time(self.start, self.end)) #ms
+
+    def get_results(self):
+        results = {"time": np.average(self.times), "times": self.times.copy()}
+        self.times = []
+        return results
+
+
+class CupyFunctions(object):
+    """Class that groups the Cupy functions on maintains state about the device"""
+
+    def __init__(self, device=0, iterations=7, compiler_options=None, observers=None):
+        """instantiate CudaFunctions object used for interacting with the CUDA device
+
+        Instantiating this object will inspect and store certain device properties at
+        runtime, which are used during compilation and/or execution of kernels by the
+        kernel tuner. It also maintains a reference to the most recently compiled
+        source module for copying data to constant memory before kernel launch.
+
+        :param device: Number of CUDA device to use for this context
+        :type device: int
+
+        :param iterations: Number of iterations used while benchmarking a kernel, 7 by default.
+        :type iterations: int
+        """
+        self.allocations = []
+        self.texrefs = []
+        if not cp:
+            raise ImportError("Error: cupy not installed, please install e.g. using 'pip install cupy'.")
+
+        #select device
+        self.dev = dev = cp.cuda.Device(device)
+        dev.use()
+
+        #inspect device properties
+        self.devprops = dev.attributes
+        self.cc = dev.compute_capability
+        self.max_threads = self.devprops['MaxThreadsPerBlock']
+
+        self.iterations = iterations
+        self.current_module = None
+        self.compiler_options = compiler_options or []
+
+        #create a stream and events
+        self.stream = cp.cuda.Stream()
+        self.start = cp.cuda.Event()
+        self.end = cp.cuda.Event()
+
+        #default dynamically allocated shared memory size, can be overwritten using smem_args
+        self.smem_size = 0
+
+        #setup observers
+        self.observers = observers or []
+        self.observers.append(CupyRuntimeObserver(self))
+        for obs in self.observers:
+            obs.register_device(self)
+
+        #collect environment information
+        env = dict()
+        cupy_info = str(cp._cupyx.get_runtime_info()).split("\n")[:-1]
+        info_dict = {s.split(":")[0].strip():s.split(":")[1].strip() for s in cupy_info}
+        env["device_name"] = info_dict[f'Device {device} Name']
+
+        env["cuda_version"] = cp.cuda.runtime.driverGetVersion()
+        env["compute_capability"] = self.cc
+        env["iterations"] = self.iterations
+        env["compiler_options"] = compiler_options
+        env["device_properties"] = self.devprops
+        self.env = env
+        self.name = env["device_name"]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
+    def ready_argument_list(self, arguments):
+        """ready argument list to be passed to the kernel, allocates gpu mem
+
+        :param arguments: List of arguments to be passed to the kernel.
+            The order should match the argument list on the CUDA kernel.
+            Allowed values are numpy.ndarray, and/or numpy.int32, numpy.float32, and so on.
+        :type arguments: list(numpy objects)
+
+        :returns: A list of arguments that can be passed to an CUDA kernel.
+        :rtype: list( cupy.ndarray, numpy.int32, ... )
+        """
+        gpu_args = []
+        for arg in arguments:
+            # if arg i is a numpy array copy to device
+            if isinstance(arg, np.ndarray):
+                alloc = cp.array(arg)
+                self.allocations.append(alloc)
+                gpu_args.append(alloc)
+            else: # if not an array, just pass argument along
+                gpu_args.append(arg)
+        return gpu_args
+
+
+    def compile(self, kernel_instance):
+        """call the CUDA compiler to compile the kernel, return the device function
+
+        :param kernel_name: The name of the kernel to be compiled, used to lookup the
+            function after compilation.
+        :type kernel_name: string
+
+        :param kernel_string: The CUDA kernel code that contains the function `kernel_name`
+        :type kernel_string: string
+
+        :returns: An CUDA kernel that can be called directly.
+        :rtype: cupy.RawKernel
+        """
+        kernel_string = kernel_instance.kernel_string
+        kernel_name = kernel_instance.name
+
+        #try:
+        if True:
+            #no_extern_c = 'extern "C"' in kernel_string
+
+            compiler_options = ['--std=c++11']  #['-Xcompiler=-Wall']
+            if self.compiler_options:
+                compiler_options += self.compiler_options
+
+            #self.current_module = self.source_mod(kernel_string, options=compiler_options + ["-e", kernel_name],
+            #                                 arch=('compute_' + self.cc) if self.cc != "00" else None,
+            #                                 code=('sm_' + self.cc) if self.cc != "00" else None,
+            #                                 cache_dir=False, no_extern_c=no_extern_c)
+
+            options = tuple(compiler_options)
+
+            self.current_module = cp.RawModule(code=kernel_string, options=options,
+                                               name_expressions=[kernel_name])
+
+            func = self.current_module.get_function(kernel_name)
+            self.func = func
+            return func
+
+        #except drv.CompileError as e:
+        #    if "uses too much shared data" in e.stderr:
+        #        raise Exception("uses too much shared data")
+        #    else:
+        #        raise e
+        
+
+
+    def benchmark(self, func, gpu_args, threads, grid):
+        """runs the kernel and measures time repeatedly, returns average time
+
+        Runs the kernel and measures kernel execution time repeatedly, number of
+        iterations is set during the creation of CudaFunctions. Benchmark returns
+        a robust average, from all measurements the fastest and slowest runs are
+        discarded and the rest is included in the returned average. The reason for
+        this is to be robust against initialization artifacts and other exceptional
+        cases.
+
+        :param func: A cupy kernel compiled for this specific kernel configuration
+        :type func: cupy.RawKernel
+
+        :param gpu_args: A list of arguments to the kernel, order should match the
+            order in the code. Allowed values are either variables in global memory
+            or single values passed by value.
+        :type gpu_args: list( cupy.ndarray, numpy.int32, ...)
+
+        :param threads: A tuple listing the number of threads in each dimension of
+            the thread block
+        :type threads: tuple(int, int, int)
+
+        :param grid: A tuple listing the number of thread blocks in each dimension
+            of the grid
+        :type grid: tuple(int, int)
+
+        :returns: A dictionary with benchmark results.
+        :rtype: dict()
+        """
+        result = dict()
+        self.dev.synchronize()
+        for _ in range(self.iterations):
+            self.start.record(stream=self.stream)
+            for obs in self.observers:
+                obs.before_start()
+            self.run_kernel(func, gpu_args, threads, grid, stream=self.stream)
+            self.end.record(stream=self.stream)
+            for obs in self.observers:
+                obs.after_start()
+            while not self.end.done:
+                for obs in self.observers:
+                    obs.during()
+            for obs in self.observers:
+                obs.after_finish()
+
+        for obs in self.observers:
+            result.update(obs.get_results())
+
+        return result
+
+    def copy_constant_memory_args(self, cmem_args):
+        """adds constant memory arguments to the most recently compiled module
+
+        :param cmem_args: A dictionary containing the data to be passed to the
+            device constant memory. The format to be used is as follows: A
+            string key is used to name the constant memory symbol to which the
+            value needs to be copied. Similar to regular arguments, these need
+            to be numpy objects, such as numpy.ndarray or numpy.int32, and so on.
+        :type cmem_args: dict( string: numpy.ndarray, ... )
+        """
+        logging.debug('copy_constant_memory_args called')
+        logging.debug('current module: ' + str(self.current_module))
+
+        """
+        for k, v in cmem_args.items():
+            symbol = self.current_module.get_global(k)[0]
+            logging.debug('copying to symbol: ' + str(symbol))
+            logging.debug('array to be copied: ')
+            logging.debug(v.nbytes)
+            logging.debug(v.dtype)
+            logging.debug(v.flags)
+            drv.memcpy_htod(symbol, v)
+        """
+
+    def copy_shared_memory_args(self, smem_args):
+        """add shared memory arguments to the kernel"""
+        self.smem_size = smem_args["size"]
+
+    def copy_texture_memory_args(self, texmem_args):
+        """adds texture memory arguments to the most recently compiled module
+
+        :param texmem_args: A dictionary containing the data to be passed to the
+            device texture memory. See tune_kernel().
+        :type texmem_args: dict
+        """
+        filter_mode_map = { 'point': drv.filter_mode.POINT,
+                            'linear': drv.filter_mode.LINEAR }
+        address_mode_map = { 'border': drv.address_mode.BORDER,
+                             'clamp': drv.address_mode.CLAMP,
+                             'mirror': drv.address_mode.MIRROR,
+                             'wrap': drv.address_mode.WRAP }
+
+        logging.debug('copy_texture_memory_args called')
+        logging.debug('current module: ' + str(self.current_module))
+
+        """
+        self.texrefs = []
+        for k, v in texmem_args.items():
+            tex = self.current_module.get_texref(k)
+            self.texrefs.append(tex)
+
+            logging.debug('copying to texture: ' + str(k))
+            if not isinstance(v, dict):
+                data = v
+            else:
+                data = v['array']
+            logging.debug('texture to be copied: ')
+            logging.debug(data.nbytes)
+            logging.debug(data.dtype)
+            logging.debug(data.flags)
+
+            drv.matrix_to_texref(data, tex, order="C")
+
+            if isinstance(v, dict):
+                if 'address_mode' in v and v['address_mode'] is not None:
+                    # address_mode is set per axis
+                    amode = v['address_mode']
+                    if not isinstance(amode, list):
+                        amode = [ amode ] * data.ndim
+                    for i, m in enumerate(amode):
+                        try:
+                            if m is not None:
+                                tex.set_address_mode(i, address_mode_map[m])
+                        except KeyError:
+                            raise ValueError('Unknown address mode: ' + m)
+                if 'filter_mode' in v and v['filter_mode'] is not None:
+                    fmode = v['filter_mode']
+                    try:
+                        tex.set_filter_mode(filter_mode_map[fmode])
+                    except KeyError:
+                        raise ValueError('Unknown filter mode: ' + fmode)
+                if 'normalized_coordinates' in v and v['normalized_coordinates']:
+                    tex.set_flags(tex.get_flags() | drv.TRSF_NORMALIZED_COORDINATES)
+
+        """
+
+    def run_kernel(self, func, gpu_args, threads, grid, stream=None):
+        """runs the CUDA kernel passed as 'func'
+
+        :param func: A cupy kernel compiled for this specific kernel configuration
+        :type func: cupy.RawKernel
+
+        :param gpu_args: A list of arguments to the kernel, order should match the
+            order in the code. Allowed values are either variables in global memory
+            or single values passed by value.
+        :type gpu_args: list( cupy.ndarray, numpy.int32, ...)
+
+        :param threads: A tuple listing the number of threads in each dimension of
+            the thread block
+        :type threads: tuple(int, int, int)
+
+        :param grid: A tuple listing the number of thread blocks in each dimension
+            of the grid
+        :type grid: tuple(int, int)
+        """
+        #func(*gpu_args, block=threads, grid=grid, stream=stream, shared=self.smem_size, texrefs=self.texrefs)
+        func(grid, threads, gpu_args, stream=stream, shared_mem=self.smem_size)
+
+    def memset(self, allocation, value, size):
+        """set the memory in allocation to the value in value
+
+        :param allocation: A GPU memory allocation unit
+        :type allocation: cupy.ndarray
+
+        :param value: The value to set the memory to
+        :type value: a single 8-bit unsigned int
+
+        :param size: The size of to the allocation unit in bytes
+        :type size: int
+
+        """
+        allocation[:] = value
+        #drv.memset_d8(allocation, value, size)
+
+
+    def memcpy_dtoh(self, dest, src):
+        """perform a device to host memory copy
+
+        :param dest: A numpy array in host memory to store the data
+        :type dest: numpy.ndarray
+
+        :param src: A GPU memory allocation unit
+        :type src: cupy.ndarray
+        """
+        #
+        #if isinstance(src, drv.DeviceAllocation):
+        #    drv.memcpy_dtoh(dest, src)
+        #else:
+        #    dest = src
+        if isinstance(dest, np.ndarray):
+            tmp = cp.asnumpy(src)
+            np.copyto(dest, tmp)
+        elif isinstance(dest, cp.ndarray):
+            cp.copyto(dest, src)
+        else:
+            raise ValueError("dest type not supported")
+        #dest[:] = cp.asnumpy(src)
+
+    def memcpy_htod(self, dest, src):
+        """perform a host to device memory copy
+
+        :param dest: A GPU memory allocation unit
+        :type dest: cupy.ndarray
+
+        :param src: A numpy array in host memory to store the data
+        :type src: numpy.ndarray
+        """
+        #if isinstance(dest, drv.DeviceAllocation):
+        #    drv.memcpy_htod(dest, src)
+        #else:
+        #    dest = src
+        if isinstance(src, np.ndarray):
+            src = cp.asarray(src)
+        cp.copyto(dest, src)
+        #dest = cp.asarray(src)
+
+    units = {'time': 'ms'}

--- a/kernel_tuner/interface.py
+++ b/kernel_tuner/interface.py
@@ -88,7 +88,7 @@ _kernel_options = Options([("kernel_name", ("""The name of the kernel in the cod
             the kernel.""", "string or list and/or callable")),
                            ("lang", ("""Specifies the language used for GPU kernels. The kernel_tuner
         automatically detects the language, but if it fails, you may specify
-        the language using this argument, currently supported: "CUDA",
+        the language using this argument, currently supported: "CUDA", "Cupy",
         "OpenCL", or "C".""", "string")),
                            ("problem_size", ("""The size of the domain from which the grid dimensions
             of the kernel are computed.
@@ -386,7 +386,7 @@ def tune_kernel(kernel_name, kernel_string, problem_size, arguments, tune_params
     if log:
         logging.basicConfig(filename=kernel_name + datetime.now().strftime('%Y%m%d-%H:%M:%S') + '.log', level=log)
 
-    kernel_source = core.KernelSource(kernel_string, lang)
+    kernel_source = core.KernelSource(kernel_name, kernel_string, lang)
 
     _check_user_input(kernel_name, kernel_source, arguments, block_size_names)
 
@@ -514,7 +514,7 @@ def run_kernel(kernel_name, kernel_string, problem_size, arguments, params, grid
     if log:
         logging.basicConfig(filename=kernel_name + datetime.now().strftime('%Y%m%d-%H:%M:%S') + '.log', level=log)
 
-    kernel_source = core.KernelSource(kernel_string, lang)
+    kernel_source = core.KernelSource(kernel_name, kernel_string, lang)
 
     _check_user_input(kernel_name, kernel_source, arguments, block_size_names)
 

--- a/kernel_tuner/kernelbuilder.py
+++ b/kernel_tuner/kernelbuilder.py
@@ -30,7 +30,7 @@ class PythonKernel(object):
 
         """
         #construct device interface
-        kernel_source = core.KernelSource(kernel_string, lang)
+        kernel_source = core.KernelSource(kernel_name, kernel_string, lang)
         self.dev = core.DeviceInterface(kernel_source, device=device, quiet=True)
         if not params:
             params = {}

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -11,6 +11,7 @@ import warnings
 import re
 
 import numpy as np
+import cupy as cp
 
 default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 
@@ -57,7 +58,7 @@ def check_argument_list(kernel_name, kernel_string, args):
         for (i, arg) in enumerate(args):
             kernel_argument = arguments[i]
 
-            if not isinstance(arg, (np.ndarray, np.generic)):
+            if not isinstance(arg, (np.ndarray, np.generic, cp.ndarray)):
                 raise TypeError(
                     "Argument at position " + str(i) + " of type: " +
                     str(type(arg)) +

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -11,7 +11,10 @@ import warnings
 import re
 
 import numpy as np
-import cupy as cp
+try:
+    import cupy as cp
+except ImportError:
+    cp = np
 
 default_block_size_names = ["block_size_x", "block_size_y", "block_size_z"]
 

--- a/test/test_c_functions.py
+++ b/test/test_c_functions.py
@@ -129,7 +129,7 @@ def test_compile(npct, subprocess):
 
     kernel_string = "this is a fake C program"
     kernel_name = "blabla"
-    kernel_sources = KernelSource(kernel_string, "C")
+    kernel_sources = KernelSource(kernel_name, kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
     with CFunctions() as cfunc:
@@ -159,7 +159,7 @@ def test_compile_detects_device_code(npct, subprocess):
 
     kernel_string = "this code clearly contains device code __global__ kernel(float* arg){ return; }"
     kernel_name = "blabla"
-    kernel_sources = KernelSource(kernel_string, "C")
+    kernel_sources = KernelSource(kernel_name, kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
     with CFunctions() as cfunc:
@@ -237,7 +237,7 @@ def test_complies_fortran_function_no_module():
     end function my_test_function
     """
     kernel_name = "my_test_function"
-    kernel_sources = KernelSource(kernel_string, "C")
+    kernel_sources = KernelSource(kernel_name, kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
     with CFunctions(compiler="gfortran") as cfunc:
@@ -266,7 +266,7 @@ def test_complies_fortran_function_with_module():
     end module my_fancy_module
     """
     kernel_name = "my_test_function"
-    kernel_sources = KernelSource(kernel_string, "C")
+    kernel_sources = KernelSource(kernel_name, kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
     try:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -35,10 +35,11 @@ def env():
     args = get_vector_add_args()
     params = {"block_size_x": 128}
 
+    kernel_name = "vector_add"
     lang = "CUDA"
-    kernel_source = core.KernelSource(kernel_string, lang)
+    kernel_source = core.KernelSource(kernel_name, kernel_string, lang)
     verbose = True
-    kernel_options = Options(kernel_name="vector_add", kernel_string=kernel_string, problem_size=args[-1],
+    kernel_options = Options(kernel_name=kernel_name, kernel_string=kernel_string, problem_size=args[-1],
                              arguments=args, lang=lang, grid_div_x=None, grid_div_y=None, grid_div_z=None,
                              cmem_args=None, texmem_args=None, block_size_names=None)
     device_options = Options(device=0, platform=0, quiet=False, compiler=None, compiler_options=None)
@@ -93,7 +94,7 @@ def test_default_verify_function(env):
 def test_check_kernel_output(dev_func_interface):
     dev_func_interface.configure_mock(**mock_config)
 
-    dev = core.DeviceInterface(core.KernelSource("", lang="CUDA"))
+    dev = core.DeviceInterface(core.KernelSource("name", "", lang="CUDA"))
     dfi = dev.dev
 
     answer = [np.zeros(4).astype(np.float32)]

--- a/test/test_cuda_functions.py
+++ b/test/test_cuda_functions.py
@@ -41,8 +41,9 @@ def test_compile():
     }
     """
 
-    kernel_sources = KernelSource(kernel_string, "cuda")
-    kernel_instance = KernelInstance("vector_add", kernel_sources, kernel_string, [], None, None, dict(), [])
+    kernel_name = "vector_add"
+    kernel_sources = KernelSource(kernel_name, kernel_string, "cuda")
+    kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
     with cuda.CudaFunctions(0) as dev:
         try:
             dev.compile(kernel_instance)

--- a/test/test_cuda_mocked.py
+++ b/test/test_cuda_mocked.py
@@ -57,8 +57,9 @@ def test_compile(drv, *args):
 
         # call compile
         kernel_string = "__global__ void vector_add()"
-        kernel_sources = KernelSource(kernel_string, "cuda")
-        kernel_instance = KernelInstance("vector_add", kernel_sources, kernel_string, [], None, None, dict(), [])
+        kernel_name = "vector_add"
+        kernel_sources = KernelSource(kernel_name, kernel_string, "cuda")
+        kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
         func = dev.compile(kernel_instance)
 
         # verify behavior

--- a/test/test_opencl_functions.py
+++ b/test/test_opencl_functions.py
@@ -45,7 +45,7 @@ def test_compile():
     }
     """
 
-    kernel_sources = KernelSource(original_kernel, "opencl")
+    kernel_sources = KernelSource("sum", original_kernel, "opencl")
     kernel_string = original_kernel.replace("shared_size", str(1024))
     kernel_instance = KernelInstance("sum", kernel_sources, kernel_string, [], None, None, dict(), [])
 

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -211,7 +211,7 @@ def test_detect_language3():
 @skip_if_no_cuda
 def test_get_device_interface1():
     lang = "CUDA"
-    with core.DeviceInterface(core.KernelSource("", lang=lang)) as dev:
+    with core.DeviceInterface(core.KernelSource("", "", lang=lang)) as dev:
         assert isinstance(dev, core.DeviceInterface)
         assert isinstance(dev.dev, cuda.CudaFunctions)
 
@@ -219,7 +219,7 @@ def test_get_device_interface1():
 @skip_if_no_opencl
 def test_get_device_interface2():
     lang = "OpenCL"
-    with core.DeviceInterface(core.KernelSource("", lang=lang)) as dev:
+    with core.DeviceInterface(core.KernelSource("", "", lang=lang)) as dev:
         assert isinstance(dev, core.DeviceInterface)
         assert isinstance(dev.dev, opencl.OpenCLFunctions)
 


### PR DESCRIPTION
Related to issue #103, I've reimplemented a cupy-based backend.

Cupy in turn uses NVRTC, which has some quirks, for example there is no host code allowed in code that is compiled with NVRTC. And haven't tested it yet, but using header files might give issues as well. 

The good news is that you can now call tune_kernel in this way:
```
tune_kernel("vector_add<float>", kernel_string, size, args, tune_params)
```
To specify a fixed template parameter of a templated CUDA kernel. Kernel Tuner will detect this use-case and switch to the Cupy backend instead of the PyCuda backend. You can also specify ``lang="Cupy"`` to enforce using the Cupy backend.

Another issue is that the initialization of Cupy is terribly slow compared to PyCuda, but it seems the Cupy developers are aware of that.

constant memory and texture memory are not yet implemented for the Cupy backend.
