### PR TITLE
Templated kernels with PyCUDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - option to simulate auto-tuning searches from existing cache files
 - Cupy backend to support C++ templated CUDA kernels
 - support for templated CUDA kernels using PyCUDA backend
+- documentation on tunable parameter vocabulary
 
 ## [0.3.2] - 2020-11-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - support for NVML tunable parameters
 - option to simulate auto-tuning searches from existing cache files
 - Cupy backend to support C++ templated CUDA kernels
+- support for templated CUDA kernels using PyCUDA backend
 
 ## [0.3.2] - 2020-11-04
 ### Added

--- a/doc/source/design.rst
+++ b/doc/source/design.rst
@@ -96,7 +96,7 @@ kernel_tuner.runners.sequential.SequentialRunner
 
 kernel_tuner.runners.sequential.SimulationRunner
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. autoclass:: kernel_tuner.runners.sequential.SimulationRunner
+.. autoclass:: kernel_tuner.runners.simulation.SimulationRunner
     :special-members: __init__
     :members:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -21,6 +21,7 @@ Contents:
    hostcode
    templates
    user-api
+   vocabulary
    design
    contributing
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,6 +19,7 @@ Contents:
    matrix_multiplication
    correctness
    hostcode
+   templates
    user-api
    design
    contributing

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -1,0 +1,78 @@
+.. highlight:: python
+    :linenothreshold: 5
+
+
+
+Templated kernels
+-----------------
+
+It is quite common in CUDA programming to write kernels that use C++ templates. This can be very useful when writing code that can work for several types, for example floats and doubles. However, the use of C++ templates makes it slightly more difficult to directly 
+integrate the CUDA kernel into applications that are not written in C++, for example Matlab, Fortran, or Python. And since Kernel Tuner is written in Python, we needed to take a few extra steps to provide support for templated CUDA kernels. Let's first look at an 
+example of what it's like to tune a templated kernel with Kernel Tuner.
+
+Example
+~~~~~~~
+
+Say we have a templated CUDA kernel in a file called vector_add.cu:
+
+.. code-block:: cuda
+
+    template<typename T>
+    __global__ void vector_add(T *c, T *a, T *b, int n) {
+        auto i = blockIdx.x * block_size_x + threadIdx.x;
+        if (i<n) {
+            c[i] = a[i] + b[i];
+        }
+    }
+
+Then the Python script to tune this kernel would be as follows:
+
+.. code-block:: python
+
+    import numpy
+    from kernel_tuner import tune_kernel
+
+    size = 1000000
+
+    a = numpy.random.randn(size).astype(numpy.float32)
+    b = numpy.random.randn(size).astype(numpy.float32)
+    c = numpy.zeros_like(b)
+    n = numpy.int32(size)
+
+    args = [c, a, b, n]
+
+    tune_params = dict()
+    tune_params["block_size_x"] = [128+64*i for i in range(15)]
+
+    tune_kernel("vector_add<float>", "vector_add.cu", size, args, tune_params)
+
+What you can see is that in the Python code we specify the template instantiation to use. Kernel Tuner will detect the use of templated kernels when the kernel_name positional argument to tune_kernel contains a template argument.
+
+This feature also allows use to auto-tune template parameters to the kernel. We could for example define a tunable parameter:
+
+.. code-block:: python
+    tune_params["my_type"] = ["float", "double"]
+
+and call tune_kernel using a tunable parameter inside the template arguments:
+
+.. code-block:: python
+    tune_kernel("vector_add<my_type>", "vector_add.cu", size, args, tune_params)
+
+Selecting a backend
+~~~~~~~~~~~~~~~~~~~
+
+Kernel Tuner supports multiple backends, for CUDA these are based on PyCUDA and Cupy. The following explains how to enable tuning of templated kernels with either backend.
+
+The PyCuda backend is the default backend in Kernel Tuner and is selected if the user does not supply the 'lang' option and CUDA code is detected in the kernel source, or when lang is set to "CUDA" by the user. PyCuda requires CUDA kernels to have extern C linkage, 
+which means that C++ templated kernels are not supported. To support templated kernels regardless of this limitation Kernel Tuner attempts to wrap the templated CUDA kernel by inserting a compile-time template instantiation statement and a wrapper kernel that calls 
+the templated CUDA kernel, which is actually demoted to a __device__ function in the process. These automatic code rewrites have a real risk of breaking the code. To minimize the chance of errors due to Kernel Tuner's automatic code rewrites, it's best to isolate the 
+templated kernel in a single source file and include it where needed in the larger application.
+
+The Cupy backend provides much more advanced support for C++ templated kernels, because it internally uses NVRTC, the Nvidia runtime compiler. NVRTC does come with some restrictions however, for example NVRTC does not allow any host code to be inside code that
+is passed. So, like with the PyCuda backend it helps to separate the source code of device and host functions into seperate files. You can force Kernel Tuner to use the Cupy backend by passing the lang="cupy" option to tune_kernel. 
+
+
+
+
+
+

--- a/doc/source/vocabulary.rst
+++ b/doc/source/vocabulary.rst
@@ -1,0 +1,48 @@
+.. highlight:: python
+    :linenothreshold: 50
+
+
+Parameter Vocabulary
+--------------------
+
+There are certain tunable parameters that have special meaning in Kernel Tuner.
+This document specifies which parameters are special and what there uses are when auto-tuning GPU kernels.
+
+In general, it is best to avoid using these parameter names for purposes other than the ones indicated in this document.
+
+.. code-block:: python
+
+    kernel_tuner #is inserted by Kernel Tuner to signal the code is compiled using the tuner
+
+    block_size_* #reserved for thread block dimensions
+    grid_size_* #reserved for grid dimensions, if you want to tune these use problem_size
+
+    compiler_opt_* #reserved for future support for tuning compiler options
+
+    loop_unroll_factor_* #reserved for tunable parameters that specify loop unrolling factors
+
+    nvml_* #reserved for tunable parameters and outputs related to NVML
+    nvml_pwr_limit #use NVML to set power limit
+    nvml_gr_clock #use NVML to set graphics clock
+    nvml_mem_clock #use NVML to set memory clock
+
+
+There are also a number of names that Kernel Tuner uses for reporting benchmarking results. 
+Because these are reported along with the tunable parameters, it is generally a good idea to not use these names for any tunable parameters.
+
+.. code-block:: python
+
+    time* #reserved for time measurements
+
+    Information that can be observed using kernel_tuner.nvml.NVMLObserver:
+    nvml_energy
+    nvml_power
+    power_readings
+    core_freq
+    mem_freq
+    temperature
+
+    ps_energy  # Energy as measured by PowerSensor
+    ps_power   # Power as measured by PowerSensor
+
+

--- a/examples/cuda-c++/vector_add.py
+++ b/examples/cuda-c++/vector_add.py
@@ -9,7 +9,7 @@ def tune():
 
     kernel_string = """
 template<typename T>
-__global__ void vector_add(T *c, T *__restrict__ a, T *b, int n) {
+__global__ void vector_add(T *c, T *a, T *b, int n) {
     auto i = blockIdx.x * block_size_x + threadIdx.x;
     if (i<n) {
         c[i] = a[i] + b[i];

--- a/examples/cuda-c++/vector_add_blocksize.py
+++ b/examples/cuda-c++/vector_add_blocksize.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-"""This is the minimal example from the README converted to C++11"""
+""" This is the example demonstrates how to use Kernel Tuner
+    to insert tunable parameters into template arguments
+"""
 
 import json
 import numpy
@@ -8,9 +10,9 @@ from kernel_tuner import tune_kernel
 def tune():
 
     kernel_string = """
-template<typename T>
-__global__ void vector_add(T *c, T *__restrict__ a, T *b, int n) {
-    auto i = blockIdx.x * block_size_x + threadIdx.x;
+template<typename T, int blockSize>
+__global__ void vector_add(T *c, T *a, T *b, int n) {
+    auto i = blockIdx.x * blockSize + threadIdx.x;
     if (i<n) {
         c[i] = a[i] + b[i];
     }
@@ -29,7 +31,7 @@ __global__ void vector_add(T *c, T *__restrict__ a, T *b, int n) {
     tune_params = dict()
     tune_params["block_size_x"] = [128+64*i for i in range(15)]
 
-    result, env = tune_kernel("vector_add<float>", kernel_string, size, args, tune_params)
+    result, env = tune_kernel("vector_add<float, block_size_x>", kernel_string, size, args, tune_params)
 
     with open("vector_add.json", 'w') as fp:
         json.dump(result, fp)

--- a/examples/cuda-c++/vector_add_cupy.py
+++ b/examples/cuda-c++/vector_add_cupy.py
@@ -8,8 +8,7 @@ from kernel_tuner import tune_kernel
 def tune():
 
     kernel_string = """
-template<typename T>
-__global__ void vector_add(T *c, T *__restrict__ a, T *b, int n) {
+template<typename T>__global__ void vector_add(T *c, T *__restrict__ a, T *b, int n) {
     auto i = blockIdx.x * block_size_x + threadIdx.x;
     if (i<n) {
         c[i] = a[i] + b[i];
@@ -29,7 +28,7 @@ __global__ void vector_add(T *c, T *__restrict__ a, T *b, int n) {
     tune_params = dict()
     tune_params["block_size_x"] = [128+64*i for i in range(15)]
 
-    result, env = tune_kernel("vector_add<float>", kernel_string, size, args, tune_params)
+    result, env = tune_kernel("vector_add<float>", kernel_string, size, args, tune_params, lang="cupy")
 
     with open("vector_add.json", 'w') as fp:
         json.dump(result, fp)

--- a/examples/cuda-c++/vector_add_cupy.py
+++ b/examples/cuda-c++/vector_add_cupy.py
@@ -2,13 +2,14 @@
 """This is the minimal example from the README converted to C++11"""
 
 import json
-import numpy
+import numpy as np
+import cupy as cp
 from kernel_tuner import tune_kernel
 
 def tune():
 
     kernel_string = """
-template<typename T>__global__ void vector_add(T *c, T *__restrict__ a, T *b, int n) {
+template<typename T>__global__ void vector_add(T *__restrict__ c, const T *__restrict__ a, const T *__restrict__ b, int n) {
     auto i = blockIdx.x * block_size_x + threadIdx.x;
     if (i<n) {
         c[i] = a[i] + b[i];
@@ -18,10 +19,10 @@ template<typename T>__global__ void vector_add(T *c, T *__restrict__ a, T *b, in
 
     size = 10000000
 
-    a = numpy.random.randn(size).astype(numpy.float32)
-    b = numpy.random.randn(size).astype(numpy.float32)
-    c = numpy.zeros_like(b)
-    n = numpy.int32(size)
+    a = cp.random.randn(size).astype(cp.float32)
+    b = cp.random.randn(size).astype(cp.float32)
+    c = cp.zeros_like(b)
+    n = np.int32(size)
 
     args = [c, a, b, n]
 

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -1,6 +1,7 @@
 """ Module for grouping the core functionality needed by most runners """
 from __future__ import print_function
 
+import re
 from collections import namedtuple
 import resource
 import logging
@@ -432,6 +433,10 @@ class DeviceInterface(object):
         name, kernel_string, temp_files = kernel_source.prepare_list_of_files(kernel_options.kernel_name, params, grid, threads,
                                                                               kernel_options.block_size_names)
 
+        #check for templated kernel
+        if kernel_source.lang == "CUDA" and "<" in name and ">" in name:
+            kernel_string, name = wrap_templated_kernel(kernel_string, name)
+
         #collect everything we know about this instance and return it
         return KernelInstance(name, kernel_source, kernel_string, temp_files, threads, grid, params, kernel_options.arguments)
 
@@ -533,3 +538,84 @@ def _default_verify_function(instance, answer, result_host, atol, verbose):
         logging.debug('correctness check has found a correctness issue')
 
     return correct
+
+
+
+#these functions facilitate compiling templated kernels with PyCuda
+def split_argument_list(argument_list):
+    """split all arguments in a list into types and names"""
+    regex = r"(.*[\s*]+)(.*)?"
+    type_list = []
+    name_list = []
+    for arg in argument_list:
+        match = re.match(regex, arg, re.S)
+        if not match:
+            raise ValueError("error parsing templated kernel argument list")
+        type_list.append(re.sub(r"\s+", " ", match.group(1).strip(), re.S))
+        name_list.append(match.group(2).strip())
+    return type_list, name_list
+
+def apply_template_typenames(type_list, templated_typenames):
+    """replace the typename tokens in type_list with their templated typenames"""
+    def replace_typename_token(matchobj):
+        """function for a whitespace preserving token regex replace"""
+        #replace only the match, leaving the whitespace around it as is
+        return matchobj.group(1) + templated_typenames[matchobj.group(2)] + matchobj.group(3)
+    for i, arg_type in enumerate(type_list):
+        for k,v in templated_typenames.items():
+            #if the templated typename occurs as a token in the string, meaning that it is enclosed in
+            #beginning of string or whitespace, and end of string, whitespace or star
+            regex = r"(^|\s+)(" + k + r")($|\s+|\*)"
+            sub = re.sub(regex, replace_typename_token, arg_type, re.S)
+            type_list[i] = sub
+
+def get_templated_typenames(template_parameters, template_arguments):
+    """based on the template parameters and arguments, create dict with templated typenames"""
+    templated_typenames = {}
+    for i, param in enumerate(template_parameters):
+        if "typename " in param:
+            typename = param[9:]
+            templated_typenames[typename] = template_arguments[i]
+    return templated_typenames
+
+def wrap_templated_kernel(kernel_string, kernel_name):
+    """rewrite kernel_string to insert wrapper function for templated kernel"""
+
+    #parse kernel_name to find template_arguments and real kernel name
+    name = kernel_name.split("<")[0]
+    template_arguments = re.search(r".*?<(.*)>", kernel_name, re.S).group(1).split(',')
+
+    #parse templated kernel definition
+    regex = r"template\s*<(.*?)>\s*__global__\s+void\s+" + name + r"\s*\((.*?)\)\s*\{"
+    match = re.search(regex, kernel_string, re.S)
+    if not match:
+        raise ValueError("could not find templated kernel definition")
+
+    template_parameters = match.group(1).split(',')
+    argument_list = match.group(2).split(',')
+    argument_list = [s.strip() for s in argument_list] #remove extra whitespace around 'type name' strings
+
+    type_list, name_list = split_argument_list(argument_list)
+
+    templated_typenames = get_templated_typenames(template_parameters, template_arguments)
+    apply_template_typenames(type_list, templated_typenames)
+
+    #replace __global__ with __device__ in the templated kernel definition
+    #could do a more precise replace, but __global__ cannot be used elsewhere in the definition
+    definition = match.group(0).replace("__global__", "__device__")
+
+    #generate code for the compile-time template instantiation
+    template_instantiation = f"template __device__ void {kernel_name}(" + ", ".join(type_list) + ");\n"
+
+    #generate code for the wrapper kernel
+    new_arg_list = ", ".join([" ".join((a, b)) for a, b in zip(type_list, name_list)])
+    wrapper_function = "\nextern \"C\" __global__ void " + name + "_wrapper(" + new_arg_list + ") {\n  " + \
+       kernel_name + "(" + ", ".join(name_list) + ");\n}\n"
+
+    #copy kernel_string, replace definition and append template instantiation and wrapper function
+    new_kernel_string = kernel_string[:]
+    new_kernel_string = new_kernel_string.replace(match.group(0), definition)
+    new_kernel_string += "\n" + template_instantiation
+    new_kernel_string += wrapper_function
+
+    return new_kernel_string, name + "_wrapper"

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -580,13 +580,14 @@ def get_templated_typenames(template_parameters, template_arguments):
 
 def wrap_templated_kernel(kernel_string, kernel_name):
     """rewrite kernel_string to insert wrapper function for templated kernel"""
-
     #parse kernel_name to find template_arguments and real kernel name
     name = kernel_name.split("<")[0]
     template_arguments = re.search(r".*?<(.*)>", kernel_name, re.S).group(1).split(',')
 
     #parse templated kernel definition
-    regex = r"template\s*<(.*?)>\s*__global__\s+void\s+" + name + r"\s*\((.*?)\)\s*\{"
+    #relatively strict regex that does not allow nested template parameters like vector<TF>
+    #within the template parameter list
+    regex = r"template\s*<([^>]*?)>\s*__global__\s+void\s+" + name + r"\s*\((.*?)\)\s*\{"
     match = re.search(regex, kernel_string, re.S)
     if not match:
         raise ValueError("could not find templated kernel definition")

--- a/roadmap.md
+++ b/roadmap.md
@@ -4,11 +4,6 @@ This roadmap presents an overview of the features we are currently planning to
 implement. Please note that this is a living document that will evolve as
 priorities grow and shift.
 
-## version 0.4.0
-
- * Support for C++ templated kernels through NVRTC and template parameter tuning
- * Document a vocabulary of reserved/special tunable parameter names
-
 ## version 0.5.0
 
  * Allow strategies to tune for a metric other than time

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -174,3 +174,46 @@ def test_default_verify_function_scalar():
             assert True
 
     assert core._default_verify_function(instance, answer, result_host, 0.1, False)
+
+
+def test_split_argument_list():
+    test_string = "T *c, const T *__restrict__ a, T\n *\n b\n , int n"
+    ans1, ans2 = core.split_argument_list([s.strip() for s in test_string.split(',')])
+    assert ans1 == ["T *", "const T *__restrict__", "T *", "int"]
+    assert ans2 == ["c", "a", "b", "n"]
+
+def test_apply_template_typenames():
+    type_list = ["T *", "CONST __restrict__", "double"]
+    templated_typenames = {"T": "test"}
+    core.apply_template_typenames(type_list, templated_typenames)
+    assert type_list == ["test *", "CONST __restrict__", "double"]
+
+def test_get_templated_typenames():
+    template_arguments = ["double", "32"]
+    template_parameters = ["typename TF", "test1", "test2"]
+
+    ans = core.get_templated_typenames(template_parameters, template_arguments)
+
+    assert len(ans) == 1
+    assert ans["TF"] == "double"
+
+def test_wrap_templated_kernel():
+    kernel_string = """
+template<typename TF> __global__ void vector_add(TF *c, const TF *__restrict__ a, TF * b , int n) {
+    auto i = blockIdx.x * block_size_x + threadIdx.x;
+    if (i<n) {
+        c[i] = a[i] + b[i];
+    }
+}
+"""
+    kernel_name = "vector_add<float>"
+    ans, _ = core.wrap_templated_kernel(kernel_string, kernel_name)
+    #check __global__ in templated definition is replaced with __device__
+    assert "template<typename TF> __device__ void vector_add" in ans
+    #check if template instantiation is inserted
+    assert "template __device__ void vector_add<float>(float *, const float *__restrict__, float *, int);" in ans
+    #check if wrapper functions with C linkage is inserted
+    assert "extern \"C\" __global__ void vector_add" in ans
+    #check if original kernel is called
+    assert "vector_add<float>(c, a, b, n);" in ans
+


### PR DESCRIPTION
This pull request adds a way to support templated CUDA kernels when using the PyCUDA backend. It does not add full C++ support, just some basic use of templates in CUDA kernels. Basically, it allows kernels that would have been able to have C linkage, except for the fact that they use templates, to still receive C linkage. We do this with a little bit of code rewriting, wrapping the kernel inside a function that can receive C linkage. It should support the basic and most common cases of using templates in CUDA kernels, which is assumed to not go beyond a few typenames (e.g. using <typename T> to write code for float or double) and setting a few constants through template arguments. More elaborate C++ kernels can use the CuPy backend, which is likely to take over as the main backend for CUDA kernels in the long run.