### PR TITLE
Fix incorrect line numbers being reported in kernel code

### DIFF
--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -422,6 +422,10 @@ def prepare_kernel_string(kernel_name, kernel_string, params, grid, threads, blo
     """
     logging.debug('prepare_kernel_string called for %s', kernel_name)
 
+    # since we insert defines above the original kernel code, the line numbers will be incorrect
+    # the following preprocessor directive informs the compiler that lines should be counted from 1
+    kernel_string = "#line 1\n" + kernel_string
+
     grid_dim_names = ["grid_size_x", "grid_size_y", "grid_size_z"]
     for i, g in enumerate(grid):
         kernel_string = f"#define {grid_dim_names[i]} {g}\n" + kernel_string

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -153,6 +153,7 @@ def test_prepare_kernel_string():
                "#define block_size_x 1\n" \
                "#define grid_size_y 7\n" \
                "#define grid_size_x 3\n" \
+               "#line 1\n" \
                "this is a weird kernel"
     assert output == expected
 


### PR DESCRIPTION
Kernel tuner inserts several defines above the users kernel source code, causing the line number for errors/warnings reported by the compiler to be incorrect. This commit fixes this issue by insert a #line preprocessor directive.

Do not merge yet. Let's see if the tests pass.