### PR TITLE
Add complex64 and complex128 to known argument types

### DIFF
--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -45,7 +45,9 @@ def check_argument_type(dtype, kernel_argument):
         "int64": ["long", "int64_t"],
         "float16": ["half"],
         "float32": ["float"],
-        "float64": ["double"]
+        "float64": ["double"],
+        "complex64": ["float2"],
+        "complex128": ["double2"]
     }
     if dtype in types_map:
         return any([substr in kernel_argument for substr in types_map[dtype]])


### PR DESCRIPTION
CUDA supports the `float2` and `double2` types for complex numbers, but kernel_tuner does not recognize the `complex64` and `complex128` as such. Therefore, these are now added to the `check_argument_type` function.