### PR TITLE
Append default block size names after checking tuning parameters

### DIFF
--- a/kernel_tuner/interface.py
+++ b/kernel_tuner/interface.py
@@ -448,6 +448,9 @@ def tune_kernel(kernel_name, kernel_source, problem_size, arguments, tune_params
     # check whether block_size_names are used as expected
     util.check_block_size_params_names_list(block_size_names, tune_params)
 
+    # ensure there is always at least three names
+    util.append_default_block_size_names(block_size_names)
+
     if iterations < 1:
         raise ValueError("Iterations should be at least one!")
 

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -106,11 +106,11 @@ def check_block_size_names(block_size_names):
             raise ValueError("block_size_names should not contain more than 3 names!")
         if not all([isinstance(name, "".__class__) for name in block_size_names]):
             raise ValueError("block_size_names should contain only strings!")
-        # ensure there is always at least three names
-        for i, name in enumerate(default_block_size_names):
-            if len(block_size_names) < i + 1:
-                block_size_names.append(name)
 
+def append_default_block_size_names(block_size_names):
+    for i, name in enumerate(default_block_size_names):
+        if len(block_size_names) < i + 1:
+            block_size_names.append(name)
 
 def check_block_size_params_names_list(block_size_names, tune_params):
     if block_size_names is not None:

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -108,6 +108,8 @@ def check_block_size_names(block_size_names):
             raise ValueError("block_size_names should contain only strings!")
 
 def append_default_block_size_names(block_size_names):
+    if block_size_names is None:
+        return
     for i, name in enumerate(default_block_size_names):
         if len(block_size_names) < i + 1:
             block_size_names.append(name)


### PR DESCRIPTION
When specifying a custom `block_size_name` for only the first dimension, (e.g. `BLOCK_SIZE_X`) the code will automatically add the default names `block_size_y` and `block_size_y`. This will cause a warning to be printed, as the latter two parameters are not in the tunable parameter list:
```
/home/veenboer/.local/lib/python3.9/site-packages/kernel_tuner/util.py:119: UserWarning: Block size name block_size_y is not specified in the tunable parameters list!
  warnings.warn("Block size name " + name + " is not specified in the tunable parameters list!", UserWarning)
/home/veenboer/.local/lib/python3.9/site-packages/kernel_tuner/util.py:119: UserWarning: Block size name block_size_z is not specified in the tunable parameters list!
  warnings.warn("Block size name " + name + " is not specified in the tunable parameters list!", UserWarning)
```
This is fixed (the warning is no longer printed) by first checking the tunable parameters list and only then adding the default block size names.