### PR TITLE
Sort for searchspace object

### DIFF
--- a/kernel_tuner/searchspace.py
+++ b/kernel_tuner/searchspace.py
@@ -13,12 +13,13 @@ supported_neighbor_methods = ['strictly-adjacent', 'adjacent', 'Hamming']
 class Searchspace():
     """ Class that offers the search space to strategies """
 
-    def __init__(self, tuning_options: dict, max_threads: int, build_neighbors_index=False, neighbor_method=None) -> None:
+    def __init__(self, tuning_options: dict, max_threads: int, build_neighbors_index=False, neighbor_method=None, sort=False, sort_last_param_first=False) -> None:
         """ Build a searchspace using the variables and constraints.
             Optionally build the neighbors index - only faster if you repeatedly look up neighbors. Methods:
                 strictly-adjacent: differs +1 or -1 parameter index value for each parameter
                 adjacent: picks closest parameter value in both directions for each parameter
                 Hamming: any parameter config with 1 different parameter value is a neighbor
+            Optionally sort the searchspace by the order in which the parameter values were specified. By default, sort goes from first to last parameter, to reverse this use sort_last_param_first.
         """
         self.tuning_options = tuning_options
         self.restrictions = tuning_options.restrictions
@@ -33,7 +34,7 @@ class Searchspace():
         if (neighbor_method is not None or build_neighbors_index) and neighbor_method not in supported_neighbor_methods:
             raise ValueError(f"Neighbor method is {neighbor_method}, must be one of {supported_neighbor_methods}")
 
-        self.list, self.__numpy, self.__dict, self.size = self.__build_searchspace()
+        self.list, self.__numpy, self.__dict, self.size = self.__build_searchspace(sort, sort_last_param_first)
         self.num_params = len(self.list[0])
         self.indices = np.arange(self.size)
         if neighbor_method is not None and neighbor_method != 'Hamming':
@@ -41,7 +42,7 @@ class Searchspace():
         if build_neighbors_index:
             self.neighbors_index = self.__build_neighbors_index(neighbor_method)
 
-    def __build_searchspace(self) -> Tuple[List[tuple], np.ndarray, dict, int]:
+    def __build_searchspace(self, sort: bool, sort_last_param_first: bool) -> Tuple[List[tuple], np.ndarray, dict, int]:
         """ compute valid configurations in a search space based on restrictions and max_threads, returns the searchspace, a dict of the searchspace for fast lookups and the size """
 
         # instantiate the parameter space with all the variables
@@ -62,14 +63,26 @@ class Searchspace():
         parameter_space = parameter_space.getSolutions()
 
         # form the parameter tuples in the order specified by tune_params.keys()
-        parameter_space_list = list()
-        for params in parameter_space:
-            param_config = tuple(params[param_name] for param_name in self.param_names)
-            parameter_space_list.append(param_config)
+        parameter_space_list = list((tuple(params[param_name] for param_name in self.param_names)) for params in parameter_space)
 
-        # in orded to have the tuples as tuples in numpy, the types are set with a string, but this will make the type np.void
+        # in order to have the tuples as tuples in numpy, the types are set with a string, but this will make the type np.void
         # type_string = ",".join(list(type(param).__name__ for param in parameter_space_list[0]))
         parameter_space_numpy = np.array(parameter_space_list)
+
+        # sort the parameter space on the order of parameters and their values as specified
+        if sort is True:
+            params_values_indices = list(self.get_param_indices(param_config) for param_config in parameter_space_list)
+            params_values_indices_dict = dict(zip(params_values_indices, list(range(len(params_values_indices)))))
+
+            # Python's built-in sort will sort starting in front, so if we want to vary the first parameter the tuple needs to be reversed
+            params_values_indices.sort(key=lambda t: tuple(reversed(t))) if sort_last_param_first else params_values_indices.sort()
+
+            # find the index of the parameter configuration for each parameter value index, using a dict to do it in constant time
+            new_order = [params_values_indices_dict.get(param_values_indices) for param_values_indices in params_values_indices]
+            # apply the new order
+            parameter_space_list = [parameter_space_list[i] for i in new_order]
+
+        # create a dictionary with the hashed parameter configurations as keys and indices as values for fast lookups
         parameter_space_dict = dict(zip(parameter_space_list, list(range(parameter_space_numpy.size))))
 
         # check for duplicates
@@ -120,7 +133,7 @@ class Searchspace():
 
     def get_param_config_index(self, param_config: tuple):
         """ Lookup the index for a parameter configuration, returns None if not found """
-        #1 pros: constant time O(1) access - much faster than any other method, cons: need to keep a shadow dict of the search space
+        # constant time O(1) access - much faster than any other method, but needs a shadow dict of the search space
         return self.__dict.get(param_config, None)
 
     def __prepare_neighbors_index(self):

--- a/kernel_tuner/searchspace.py
+++ b/kernel_tuner/searchspace.py
@@ -65,10 +65,6 @@ class Searchspace():
         # form the parameter tuples in the order specified by tune_params.keys()
         parameter_space_list = list((tuple(params[param_name] for param_name in self.param_names)) for params in parameter_space)
 
-        # in order to have the tuples as tuples in numpy, the types are set with a string, but this will make the type np.void
-        # type_string = ",".join(list(type(param).__name__ for param in parameter_space_list[0]))
-        parameter_space_numpy = np.array(parameter_space_list)
-
         # sort the parameter space on the order of parameters and their values as specified
         if sort is True:
             params_values_indices = list(self.get_param_indices(param_config) for param_config in parameter_space_list)
@@ -81,6 +77,11 @@ class Searchspace():
             new_order = [params_values_indices_dict.get(param_values_indices) for param_values_indices in params_values_indices]
             # apply the new order
             parameter_space_list = [parameter_space_list[i] for i in new_order]
+
+        # create a numpy array of the search space
+        # in order to have the tuples as tuples in numpy, the types are set with a string, but this will make the type np.void
+        # type_string = ",".join(list(type(param).__name__ for param in parameter_space_list[0]))
+        parameter_space_numpy = np.array(parameter_space_list)
 
         # create a dictionary with the hashed parameter configurations as keys and indices as values for fast lookups
         parameter_space_dict = dict(zip(parameter_space_list, list(range(parameter_space_numpy.size))))

--- a/kernel_tuner/strategies/brute_force.py
+++ b/kernel_tuner/strategies/brute_force.py
@@ -29,7 +29,7 @@ def tune(runner, kernel_options, device_options, tuning_options):
     """
 
     # create the searchspace
-    searchspace = Searchspace(tuning_options, runner.dev.max_threads)
+    searchspace = Searchspace(tuning_options, runner.dev.max_threads, sort=True)
 
     # call the runner
     results, env = runner.run(searchspace.list, kernel_options, tuning_options)

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -842,7 +842,7 @@ class MaxProdConstraint(Constraint):
                 if variable not in assignments:
                     domain = domains[variable]
                     for value in domain[:]:
-                        if prod + value > maxprod:
+                        if prod * value > maxprod:
                             domain.hideValue(value)
                     if not domain:
                         return False

--- a/test/test_searchspace.py
+++ b/test/test_searchspace.py
@@ -281,3 +281,17 @@ def test_order_param_configs():
     for expected_param_config in expected_order:
         assert expected_param_config in ordered_neighbors
     assert len(ordered_neighbors) == len(expected_order)
+
+
+def test_max_threads():
+    max_threads = 1024
+    tune_params = dict()
+    tune_params["block_size_x"] = [512, 1024]
+    tune_params["block_size_y"] = [1]
+    tuning_options = Options(dict(tune_params=tune_params, restrictions=None))
+
+    searchspace = Searchspace(tuning_options, max_threads)
+
+    print(searchspace.list)
+
+    assert len(searchspace.list) > 1

--- a/test/test_searchspace.py
+++ b/test/test_searchspace.py
@@ -16,6 +16,7 @@ from constraint import ExactSumConstraint, FunctionConstraint
 import numpy as np
 
 max_threads = 1024
+value_error_expectation_message = "Expected a ValueError to be raised"
 
 # 9 combinations without restrictions
 simple_tune_params = OrderedDict()
@@ -39,6 +40,13 @@ min_func = lambda gpu1, gpu2, gpu3, gpu4: min([gpu1, gpu2, gpu3, gpu4]) >= 1
 # test three different types of restrictions: python-constraint, a function and a string
 restrict = [ExactSumConstraint(num_layers), FunctionConstraint(min_func)]
 
+# 74088 combinations intended to test whether sorting works
+sort_tune_params = OrderedDict()
+sort_tune_params["gpu1"] = list(range(num_layers))
+sort_tune_params["gpu2"] = list(range(num_layers))
+sort_tune_params["gpu3"] = list(range(num_layers))
+sort_tuning_options = Options(dict(restrictions=[], tune_params=sort_tune_params))
+
 # create the searchspace object
 tuning_options = Options(dict(restrictions=restrict, tune_params=tune_params))
 searchspace = Searchspace(tuning_options, max_threads)
@@ -59,6 +67,31 @@ def test_internal_representation():
     for index, dict_config in enumerate(searchspace.get_list_dict().keys()):
         assert dict_config == searchspace.list[index]
 
+def test_sort():
+    """ test that the sort searchspace option works as expected """
+    simple_searchspace_sort = Searchspace(simple_tuning_options, max_threads, sort=True, sort_last_param_first=False)
+    assert simple_searchspace_sort.list == [(1, 4, 'string_1'), (1, 4, 'string_2'), (1, 5.5, 'string_1'), (1, 5.5, 'string_2'), (2, 4, 'string_1'), (2, 4, 'string_2'), (2, 5.5, 'string_1'), (2, 5.5, 'string_2'), (3, 4, 'string_1'), (3, 4, 'string_2'), (3, 5.5, 'string_1'), (3, 5.5, 'string_2')]
+
+    searchspace_sort = Searchspace(sort_tuning_options, max_threads, sort=True, sort_last_param_first=False)
+    num_params = len(searchspace_sort.list[0])
+    for param_config_index, (param_config_first, param_config_second) in enumerate(zip(searchspace_sort.list, searchspace_sort.list[1:])):
+        if (param_config_index + 1) % num_layers == 0:
+            continue
+        for param_index in range(num_params):
+            assert param_config_first[param_index] <= param_config_second[param_index]
+
+def test_sort_reversed():
+    """ test that the sort searchspace option with the sort_last_param_first option enabled works as expected """
+    simple_searchspace_sort_reversed = Searchspace(simple_tuning_options, max_threads, sort=True, sort_last_param_first=True)
+    assert simple_searchspace_sort_reversed.list == [(1, 4, 'string_1'), (2, 4, 'string_1'), (3, 4, 'string_1'), (1, 5.5, 'string_1'), (2, 5.5, 'string_1'), (3, 5.5, 'string_1'), (1, 4, 'string_2'), (2, 4, 'string_2'), (3, 4, 'string_2'), (1, 5.5, 'string_2'), (2, 5.5, 'string_2'), (3, 5.5, 'string_2')]
+
+    searchspace_sort = Searchspace(sort_tuning_options, max_threads, sort=True, sort_last_param_first=True)
+    num_params = len(searchspace_sort.list[0])
+    for param_config_index, (param_config_first, param_config_second) in enumerate(zip(searchspace_sort.list, searchspace_sort.list[1:])):
+        if (param_config_index + 1) % num_layers == 0:
+            continue
+        for param_index in range(num_params):
+            assert param_config_first[param_index] <= param_config_second[param_index]
 
 def test_index_lookup():
     """ test that index lookups are consistent for ~1% of the searchspace """
@@ -98,12 +131,12 @@ def test_random_sample():
     # too many samples should result in a ValueError
     try:
         simple_searchspace.get_random_sample_indices(simple_searchspace.size + 1)
-        print("Expected a ValueError to be raised")
+        print(value_error_expectation_message)
         assert False
     except ValueError as e:
         assert "number of samples requested is greater than the searchspace size" in str(e)
     except Exception:
-        print("Expected a ValueError to be raised")
+        print(value_error_expectation_message)
         assert False
 
 
@@ -208,34 +241,34 @@ def test_order_param_configs():
     # test failsafe too few indices
     try:
         simple_searchspace.order_param_configs(neighbors, [1, 2])
-        print("Expected a ValueError to be raised")
+        print(value_error_expectation_message)
         assert False
     except ValueError as e:
         assert "must be equal to the number of parameters" in str(e)
     except Exception:
-        print("Expected a ValueError to be raised")
+        print(value_error_expectation_message)
         assert False
 
     # test failsafe too many indices
     try:
         simple_searchspace.order_param_configs(neighbors, [1, 2, 0, 2])
-        print("Expected a ValueError to be raised")
+        print(value_error_expectation_message)
         assert False
     except ValueError as e:
         assert "must be equal to the number of parameters" in str(e)
     except Exception:
-        print("Expected a ValueError to be raised")
+        print(value_error_expectation_message)
         assert False
 
     # test failsafe invalid indices
     try:
         simple_searchspace.order_param_configs(neighbors, [1, 3, 0])
-        print("Expected a ValueError to be raised")
+        print(value_error_expectation_message)
         assert False
     except ValueError as e:
         assert "order needs to be a list of the parameter indices, but index" in str(e)
     except Exception:
-        print("Expected a ValueError to be raised")
+        print(value_error_expectation_message)
         assert False
 
     # test usecase


### PR DESCRIPTION
Added an option for the searchspace object to be sorted during initialisation, either from first to last parameter or from last to first parameter. The compute overhead of the sorting is minimal. 