### PR TITLE
WIP: Device context handling, DeviceInterface lifetime

### DIFF
--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -255,9 +255,8 @@ class DeviceInterface(object):
         if not quiet:
             print("Using: " + self.dev.name)
 
-        dev.__enter__()
-
     def __enter__(self):
+        self.dev.__enter__()
         return self
 
     def benchmark(self, func, gpu_args, instance, verbose):

--- a/kernel_tuner/cupy.py
+++ b/kernel_tuner/cupy.py
@@ -97,8 +97,10 @@ class CupyFunctions:
         env["device_properties"] = self.devprops
         self.env = env
         self.name = env["device_name"]
+        self.dev.__exit__()
 
     def __enter__(self):
+        self.dev.__enter__()
         return self
 
     def __exit__(self, *exc):

--- a/test/test_cuda_mocked.py
+++ b/test/test_cuda_mocked.py
@@ -16,7 +16,7 @@ def setup_mock(drv):
                 'COMPUTE_CAPABILITY_MINOR': 5}
     context.return_value.get_device.return_value.get_attributes.return_value = devprops
     context.return_value.get_device.return_value.compute_capability.return_value = "55"
-    drv.Device.return_value.make_context.return_value = context()
+    drv.Device.return_value.retain_primary_context.return_value = context()
     drv.mem_alloc.return_value = 'mem_alloc'
     return drv
 

--- a/test/test_kernelbuilder.py
+++ b/test/test_kernelbuilder.py
@@ -30,6 +30,16 @@ def test_PythonKernel(test_kernel):
     reference = kernel_function(*args)
     assert np.allclose(reference[0], args[1]+args[2])
 
+@skip_if_no_cuda
+def test_PythonKernel_mixed(test_kernel):
+    kernel_name, kernel_string, n, args, params = test_kernel
+    kernel_function = kernelbuilder.PythonKernel(*test_kernel, lang="CUDA")
+    kernel_function2 = kernelbuilder.PythonKernel(*test_kernel, lang="cupy")
+    reference = kernel_function(*args)
+    reference2 = kernel_function2(*args)
+    assert np.allclose(reference[0], args[1]+args[2])
+    assert np.allclose(reference2[0], args[1]+args[2])
+
 
 @skip_if_no_cuda
 def test_PythonKernel_tuned(test_kernel):


### PR DESCRIPTION
With the new PythonKernel interface, the lifetime of a DeviceInterface object can be longer than a single tune_kernel or run_kernel call. This fundamentally changes how we need to handle device contexts, since now multiple DeviceInterface objects can be "live" at the same time outside of our control (especially with the randomness of the python GC). This could even involve multiple physical devices and multiple backends.

Supporting this robustly means we have to ensure that the correct (cuda) context/device is active at the right time (during construction, compilation, transferring data, calling kernels, etc) in run_kernel, tune_kernel, PythonKernel, etc, that all backends properly support switching back and forth between contexts, and the various backends don't interfere with each other and with any external code.

This PR is work in progress, also to see how feasible it is in practice without making things too error-prone or fickle. This only handles the CUDA backend currently. I haven't looked at the others yet. Any feedback or insights are very welcome.