### PR TITLE
Remove context manager behaviour of device classes

### DIFF
--- a/kernel_tuner/c.py
+++ b/kernel_tuner/c.py
@@ -73,12 +73,6 @@ class CFunctions(object):
         self.env = env
         self.name = platform.processor()
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        """CFunctions does not claim any resources that need to be released."""
-
     def ready_argument_list(self, arguments):
         """ready argument list to be passed to the C function
 

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -259,11 +259,6 @@ class DeviceInterface(object):
         if not quiet:
             print("Using: " + self.dev.name)
 
-        dev.__enter__()
-
-    def __enter__(self):
-        return self
-
 
     def benchmark_default(self, func, gpu_args, threads, grid, result):
         """ Benchmark one kernel execution at a time """
@@ -563,10 +558,6 @@ class DeviceInterface(object):
                 logging.debug('encountered unexpected runtime failure: ' + str(e))
                 raise e
         return True
-
-    def __exit__(self, *exc):
-        if hasattr(self, 'dev'):
-            self.dev.__exit__(*exc)
 
 
 def _default_verify_function(instance, answer, result_host, atol, verbose):

--- a/kernel_tuner/cupy.py
+++ b/kernel_tuner/cupy.py
@@ -58,7 +58,8 @@ class CupyFunctions:
                             "using 'pip install cupy-cuda111', please check https://github.com/cupy/cupy.")
 
         #select device
-        self.dev = dev = cp.cuda.Device(device).__enter__()
+        self.dev = dev = cp.cuda.Device(device)
+        dev.use()
 
         #inspect device properties
         self.devprops = dev.attributes
@@ -97,13 +98,6 @@ class CupyFunctions:
         env["device_properties"] = self.devprops
         self.env = env
         self.name = env["device_name"]
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        """destroy the device context"""
-        self.dev.__exit__()
 
     def ready_argument_list(self, arguments):
         """ready argument list to be passed to the kernel, allocates gpu mem

--- a/kernel_tuner/kernelbuilder.py
+++ b/kernel_tuner/kernelbuilder.py
@@ -107,7 +107,3 @@ class PythonKernel(object):
         :type *args: np.ndarray or np.generic
         """
         return self.run_kernel(args)
-
-    def __del__(self):
-        if hasattr(self, 'dev'):
-            self.dev.__exit__([None, None, None])

--- a/kernel_tuner/opencl.py
+++ b/kernel_tuner/opencl.py
@@ -75,12 +75,6 @@ class OpenCLFunctions():
         self.env = env
         self.name = dev.name
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        """OpenCLFunctions does not claim any resources that need to be released"""
-
     def ready_argument_list(self, arguments):
         """ready argument list to be passed to the kernel, allocates gpu mem
 

--- a/kernel_tuner/runners/sequential.py
+++ b/kernel_tuner/runners/sequential.py
@@ -29,7 +29,7 @@ class SequentialRunner(object):
         """
 
         #detect language and create high-level device interface
-        self.dev = DeviceInterface(kernel_source, iterations=iterations, observers=observers, **device_options).__enter__()
+        self.dev = DeviceInterface(kernel_source, iterations=iterations, observers=observers, **device_options)
 
         self.units = self.dev.units
         self.quiet = device_options.quiet
@@ -40,9 +40,6 @@ class SequentialRunner(object):
 
         #move data to the GPU
         self.gpu_args = self.dev.ready_argument_list(kernel_options.arguments)
-
-    def __enter__(self):
-        return self
 
     def run(self, parameter_space, kernel_options, tuning_options):
         """ Iterate through the entire parameter space using a single Python process
@@ -111,7 +108,3 @@ class SequentialRunner(object):
             results.append(params)
 
         return results, self.dev.get_environment()
-
-    def __exit__(self, *exc):
-        if hasattr(self, 'dev'):
-            self.dev.__exit__(*exc)

--- a/kernel_tuner/runners/simulation.py
+++ b/kernel_tuner/runners/simulation.py
@@ -44,12 +44,6 @@ class SimulationLangFunction(object):
         self.env = env
         self.name = env["device_name"]
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc):
-        return
-
 
 class SimulationDeviceInterface(object):
     """Compatibily class for DeviceInterface that offers a High-Level Device Interface to the rest of the Kernel Tuner"""
@@ -108,9 +102,6 @@ class SimulationDeviceInterface(object):
         if not self.quiet:
             print("Simulating: " + value)
 
-    def __enter__(self):
-        return self
-
     def benchmark(self, func, gpu_args, instance, verbose):
         """benchmark the kernel instance"""
         logging.debug('benchmark ' + instance.name)
@@ -165,10 +156,6 @@ class SimulationDeviceInterface(object):
         logging.debug('grid dims (%d, %d, %d)', *instance.grid)
         raise self.device_access_error
 
-    def __exit__(self, *exc):
-        if hasattr(self, 'dev'):
-            self.dev.__exit__(*exc)
-
 
 class SimulationRunner(object):
     """ SimulationRunner is used for tuning with a single process/thread """
@@ -192,7 +179,7 @@ class SimulationRunner(object):
         """
 
         # #detect language and create high-level device interface
-        self.dev = SimulationDeviceInterface(kernel_source, iterations=iterations, **device_options).__enter__()
+        self.dev = SimulationDeviceInterface(kernel_source, iterations=iterations, **device_options)
 
         self.quiet = device_options.quiet
         self.kernel_source = kernel_source
@@ -200,9 +187,6 @@ class SimulationRunner(object):
         self.simulation_mode = True
         self.last_strategy_start_time = perf_counter()
         self.units = {}
-
-    def __enter__(self):
-        return self
 
     def run(self, parameter_space, kernel_options, tuning_options):
         """ Iterate through the entire parameter space using a single Python process
@@ -242,7 +226,3 @@ class SimulationRunner(object):
             raise ValueError("Parameter element not in cache - in simulation mode, all parameter elements must be present in the cache")
 
         return results, self.dev.get_environment()
-
-    def __exit__(self, *exc):
-        if hasattr(self, 'dev'):
-            self.dev.__exit__(*exc)

--- a/test/test_c_functions.py
+++ b/test/test_c_functions.py
@@ -25,8 +25,9 @@ def test_ready_argument_list1():
     arg3 = np.array([7, 8, 9]).astype(np.int32)
     arguments = [arg1, arg2, arg3]
 
-    with CFunctions() as cfunc:
-        output = cfunc.ready_argument_list(arguments)
+    cfunc = CFunctions()
+
+    output = cfunc.ready_argument_list(arguments)
     print(output)
 
     output_arg1 = np.ctypeslib.as_array(output[0].ctypes, shape=arg1.shape)
@@ -56,8 +57,8 @@ def test_ready_argument_list2():
     arg3 = np.float32(6.0)
     arguments = [arg1, arg2, arg3]
 
-    with CFunctions() as cfunc:
-        output = cfunc.ready_argument_list(arguments)
+    cfunc = CFunctions()
+    output = cfunc.ready_argument_list(arguments)
     print(output)
 
     output_arg1 = np.ctypeslib.as_array(output[0].ctypes, shape=arg1.shape)
@@ -74,27 +75,27 @@ def test_ready_argument_list2():
 def test_ready_argument_list3():
     arg1 = Mock()
     arguments = [arg1]
-    with CFunctions() as cfunc:
-        try:
-            cfunc.ready_argument_list(arguments)
-            assert False
-        except Exception:
-            assert True
+    cfunc = CFunctions()
+    try:
+        cfunc.ready_argument_list(arguments)
+        assert False
+    except Exception:
+        assert True
 
 
 def test_ready_argument_list4():
     with raises(TypeError):
         arg1 = int(9)
-        with CFunctions() as cfunc:
-            cfunc.ready_argument_list([arg1])
+        cfunc = CFunctions()
+        cfunc.ready_argument_list([arg1])
 
 
 def test_ready_argument_list5():
     arg1 = np.array([1, 2, 3]).astype(np.float32)
     arguments = [arg1]
 
-    with CFunctions() as cfunc:
-        output = cfunc.ready_argument_list(arguments)
+    cfunc = CFunctions()
+    output = cfunc.ready_argument_list(arguments)
 
     assert all(output[0].numpy == arg1)
 
@@ -106,21 +107,21 @@ def test_ready_argument_list5():
 def test_byte_array_arguments():
     arg1 = np.array([1, 2, 3]).astype(np.int8)
 
-    with CFunctions() as cfunc:
+    cfunc = CFunctions()
 
-        output = cfunc.ready_argument_list([arg1])
+    output = cfunc.ready_argument_list([arg1])
 
-        output_arg1 = np.ctypeslib.as_array(output[0].ctypes, shape=arg1.shape)
+    output_arg1 = np.ctypeslib.as_array(output[0].ctypes, shape=arg1.shape)
 
-        assert output_arg1.dtype == 'int8'
+    assert output_arg1.dtype == 'int8'
 
-        assert all(output_arg1 == arg1)
+    assert all(output_arg1 == arg1)
 
-        dest = np.zeros_like(arg1)
+    dest = np.zeros_like(arg1)
 
-        cfunc.memcpy_dtoh(dest, output[0])
+    cfunc.memcpy_dtoh(dest, output[0])
 
-        assert all(dest == arg1)
+    assert all(dest == arg1)
 
 
 @patch('kernel_tuner.c.subprocess')
@@ -132,8 +133,8 @@ def test_compile(npct, subprocess):
     kernel_sources = KernelSource(kernel_name, kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
-    with CFunctions() as cfunc:
-        f = cfunc.compile(kernel_instance)
+    cfunc = CFunctions()
+    f = cfunc.compile(kernel_instance)
 
     print(subprocess.mock_calls)
     print(npct.mock_calls)
@@ -162,8 +163,8 @@ def test_compile_detects_device_code(npct, subprocess):
     kernel_sources = KernelSource(kernel_name, kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
-    with CFunctions() as cfunc:
-        cfunc.compile(kernel_instance)
+    cfunc = CFunctions()
+    cfunc.compile(kernel_instance)
 
     print(subprocess.check_call.call_args_list)
 
@@ -186,8 +187,8 @@ def test_memset():
     x_c = x.ctypes.data_as(C.POINTER(C.c_float))
     arg = Argument(numpy=x, ctypes=x_c)
 
-    with CFunctions() as cfunc:
-       cfunc.memset(arg, 0, x.nbytes)
+    cfunc = CFunctions()
+    cfunc.memset(arg, 0, x.nbytes)
 
     output = np.ctypeslib.as_array(x_c, shape=(4,))
 
@@ -203,8 +204,8 @@ def test_memcpy_dtoh():
     arg = Argument(numpy=x, ctypes=x_c)
     output = np.zeros_like(x)
 
-    with CFunctions() as cfunc:
-        cfunc.memcpy_dtoh(output, arg)
+    cfunc = CFunctions()
+    cfunc.memcpy_dtoh(output, arg)
 
     print(a)
     print(output)
@@ -220,8 +221,8 @@ def test_memcpy_htod():
     x_c = x.ctypes.data_as(C.POINTER(C.c_float))
     arg = Argument(numpy=x, ctypes=x_c)
 
-    with CFunctions() as cfunc:
-        cfunc.memcpy_htod(arg, src)
+    cfunc = CFunctions()
+    cfunc.memcpy_htod(arg, src)
 
     assert all(arg.numpy == a)
 
@@ -240,10 +241,10 @@ def test_complies_fortran_function_no_module():
     kernel_sources = KernelSource(kernel_name, kernel_string, "C")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
 
-    with CFunctions(compiler="gfortran") as cfunc:
-        func = cfunc.compile(kernel_instance)
+    cfunc = CFunctions(compiler="gfortran")
+    func = cfunc.compile(kernel_instance)
 
-        result = cfunc.run_kernel(func, [], (), ())
+    result = cfunc.run_kernel(func, [], (), ())
 
     assert np.isclose(result, 42.0)
 
@@ -271,10 +272,10 @@ def test_complies_fortran_function_with_module():
 
     try:
 
-        with CFunctions(compiler="gfortran") as cfunc:
-            func = cfunc.compile(kernel_instance)
+        cfunc = CFunctions(compiler="gfortran")
+        func = cfunc.compile(kernel_instance)
 
-            result = cfunc.run_kernel(func, [], (), ())
+        result = cfunc.run_kernel(func, [], (), ())
 
         assert np.isclose(result, 42.0)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -46,10 +46,10 @@ def env():
                              arguments=args, lang=lang, grid_div_x=None, grid_div_y=None, grid_div_z=None,
                              cmem_args=None, texmem_args=None, block_size_names=None)
     device_options = Options(device=0, platform=0, quiet=False, compiler=None, compiler_options=None)
-    with core.DeviceInterface(kernel_source, iterations=7, **device_options) as dev:
-        instance = dev.create_kernel_instance(kernel_source, kernel_options, params, verbose)
+    dev = core.DeviceInterface(kernel_source, iterations=7, **device_options)
+    instance = dev.create_kernel_instance(kernel_source, kernel_options, params, verbose)
 
-        yield dev, instance
+    yield dev, instance
 
 
 @skip_if_no_cuda

--- a/test/test_cuda_functions.py
+++ b/test/test_cuda_functions.py
@@ -21,12 +21,12 @@ def test_ready_argument_list():
 
     arguments = [c, a, b]
 
-    with kt_pycuda.PyCudaFunctions(0) as dev:
-        gpu_args = dev.ready_argument_list(arguments)
+    dev = kt_pycuda.PyCudaFunctions(0)
+    gpu_args = dev.ready_argument_list(arguments)
 
-        assert isinstance(gpu_args[0], pycuda.driver.DeviceAllocation)
-        assert isinstance(gpu_args[1], np.int32)
-        assert isinstance(gpu_args[2], pycuda.driver.DeviceAllocation)
+    assert isinstance(gpu_args[0], pycuda.driver.DeviceAllocation)
+    assert isinstance(gpu_args[1], np.int32)
+    assert isinstance(gpu_args[2], pycuda.driver.DeviceAllocation)
 
 
 @skip_if_no_cuda
@@ -44,11 +44,11 @@ def test_compile():
     kernel_name = "vector_add"
     kernel_sources = KernelSource(kernel_name, kernel_string, "cuda")
     kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
-    with kt_pycuda.PyCudaFunctions(0) as dev:
-        try:
-            dev.compile(kernel_instance)
-        except Exception as e:
-            pytest.fail("Did not expect any exception:" + str(e))
+    dev = kt_pycuda.PyCudaFunctions(0)
+    try:
+        dev.compile(kernel_instance)
+    except Exception as e:
+        pytest.fail("Did not expect any exception:" + str(e))
 
 
 def dummy_func(a, b, block=0, grid=0, stream=None, shared=0, texrefs=None):

--- a/test/test_cuda_mocked.py
+++ b/test/test_cuda_mocked.py
@@ -16,7 +16,7 @@ def setup_mock(drv):
                 'COMPUTE_CAPABILITY_MINOR': 5}
     context.return_value.get_device.return_value.get_attributes.return_value = devprops
     context.return_value.get_device.return_value.compute_capability.return_value = "55"
-    drv.Device.return_value.make_context.return_value = context()
+    drv.Device.return_value.retain_primary_context.return_value = context()
     drv.mem_alloc.return_value = 'mem_alloc'
     return drv
 
@@ -32,8 +32,8 @@ def test_ready_argument_list(drv, *args):
     b = np.random.randn(size).astype(np.float32)
     arguments = [a, b]
 
-    with pycuda.PyCudaFunctions(0) as dev:
-        gpu_args = dev.ready_argument_list(arguments)
+    dev = pycuda.PyCudaFunctions(0)
+    gpu_args = dev.ready_argument_list(arguments)
 
     print(drv.mock_calls)
     print(gpu_args)
@@ -51,26 +51,26 @@ def test_compile(drv, *args):
 
     # setup mocked stuff
     drv = setup_mock(drv)
-    with pycuda.PyCudaFunctions(0) as dev:
-        dev.source_mod = Mock()
-        dev.source_mod.return_value.get_function.return_value = 'func'
+    dev = pycuda.PyCudaFunctions(0)
+    dev.source_mod = Mock()
+    dev.source_mod.return_value.get_function.return_value = 'func'
 
-        # call compile
-        kernel_string = "__global__ void vector_add()"
-        kernel_name = "vector_add"
-        kernel_sources = KernelSource(kernel_name, kernel_string, "cuda")
-        kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
-        func = dev.compile(kernel_instance)
+    # call compile
+    kernel_string = "__global__ void vector_add()"
+    kernel_name = "vector_add"
+    kernel_sources = KernelSource(kernel_name, kernel_string, "cuda")
+    kernel_instance = KernelInstance(kernel_name, kernel_sources, kernel_string, [], None, None, dict(), [])
+    func = dev.compile(kernel_instance)
 
-        # verify behavior
-        assert dev.source_mod.call_count == 1
-        assert dev.current_module is dev.source_mod.return_value
-        assert func == 'func'
+    # verify behavior
+    assert dev.source_mod.call_count == 1
+    assert dev.current_module is dev.source_mod.return_value
+    assert func == 'func'
 
-        assert kernel_string == list(dev.source_mod.mock_calls[0])[1][0]
-        optional_args = list(dev.source_mod.mock_calls[0])[2]
-        assert optional_args['code'] == 'sm_55'
-        assert optional_args['arch'] == 'compute_55'
+    assert kernel_string == list(dev.source_mod.mock_calls[0])[1][0]
+    optional_args = list(dev.source_mod.mock_calls[0])[2]
+    assert optional_args['code'] == 'sm_55'
+    assert optional_args['arch'] == 'compute_55'
 
 
 def dummy_func(a, b, block=0, grid=0, shared=0, stream=None, texrefs=None):
@@ -86,14 +86,14 @@ def test_copy_constant_memory_args(drv, *args):
     fake_array = np.zeros(10).astype(np.float32)
     cmem_args = {'fake_array': fake_array}
 
-    with pycuda.PyCudaFunctions(0) as dev:
-        dev.current_module = Mock()
-        dev.current_module.get_global.return_value = ['get_global']
+    dev = pycuda.PyCudaFunctions(0)
+    dev.current_module = Mock()
+    dev.current_module.get_global.return_value = ['get_global']
 
-        dev.copy_constant_memory_args(cmem_args)
+    dev.copy_constant_memory_args(cmem_args)
 
-        drv.memcpy_htod.assert_called_once_with('get_global', fake_array)
-        dev.current_module.get_global.assert_called_once_with('fake_array')
+    drv.memcpy_htod.assert_called_once_with('get_global', fake_array)
+    dev.current_module.get_global.assert_called_once_with('fake_array')
 
 
 @patch('kernel_tuner.pycuda.nvml')
@@ -107,20 +107,20 @@ def test_copy_texture_memory_args(drv, *args):
 
     texref = Mock()
 
-    with pycuda.PyCudaFunctions(0) as dev:
-        dev.current_module = Mock()
-        dev.current_module.get_texref.return_value = texref
+    dev = pycuda.PyCudaFunctions(0)
+    dev.current_module = Mock()
+    dev.current_module.get_texref.return_value = texref
 
-        dev.copy_texture_memory_args(texmem_args)
+    dev.copy_texture_memory_args(texmem_args)
 
-        drv.matrix_to_texref.assert_called_once_with(fake_array, texref, order="C")
-        dev.current_module.get_texref.assert_called_once_with('fake_tex')
+    drv.matrix_to_texref.assert_called_once_with(fake_array, texref, order="C")
+    dev.current_module.get_texref.assert_called_once_with('fake_tex')
 
-        texmem_args = {'fake_tex2': {'array': fake_array, 'filter_mode': 'linear', 'address_mode': ['border', 'clamp']}}
+    texmem_args = {'fake_tex2': {'array': fake_array, 'filter_mode': 'linear', 'address_mode': ['border', 'clamp']}}
 
-        dev.copy_texture_memory_args(texmem_args)
-        drv.matrix_to_texref.assert_called_with(fake_array, texref, order="C")
-        dev.current_module.get_texref.assert_called_with('fake_tex2')
-        texref.set_filter_mode.assert_called_once_with(drv.filter_mode.LINEAR)
-        texref.set_address_mode.assert_any_call(0, drv.address_mode.BORDER)
-        texref.set_address_mode.assert_any_call(1, drv.address_mode.CLAMP)
+    dev.copy_texture_memory_args(texmem_args)
+    drv.matrix_to_texref.assert_called_with(fake_array, texref, order="C")
+    dev.current_module.get_texref.assert_called_with('fake_tex2')
+    texref.set_filter_mode.assert_called_once_with(drv.filter_mode.LINEAR)
+    texref.set_address_mode.assert_any_call(0, drv.address_mode.BORDER)
+    texref.set_address_mode.assert_any_call(1, drv.address_mode.CLAMP)

--- a/test/test_opencl_functions.py
+++ b/test/test_opencl_functions.py
@@ -49,10 +49,10 @@ def test_compile():
     kernel_string = original_kernel.replace("shared_size", str(1024))
     kernel_instance = KernelInstance("sum", kernel_sources, kernel_string, [], None, None, dict(), [])
 
-    with opencl.OpenCLFunctions(0) as dev:
-        func = dev.compile(kernel_instance)
+    dev = opencl.OpenCLFunctions(0)
+    func = dev.compile(kernel_instance)
 
-        assert isinstance(func, pyopencl.Kernel)
+    assert isinstance(func, pyopencl.Kernel)
 
 
 def fun_test(queue, a, b, block=0, grid=0):
@@ -63,11 +63,11 @@ def fun_test(queue, a, b, block=0, grid=0):
 
 @pytest.fixture
 def create_benchmark_args():
-    with opencl.OpenCLFunctions(0) as dev:
-        args = [1, 2]
-        times = tuple(range(1, 4))
+    dev = opencl.OpenCLFunctions(0)
+    args = [1, 2]
+    times = tuple(range(1, 4))
 
-        yield dev, args, times
+    yield dev, args, times
 
 
 
@@ -80,5 +80,5 @@ def test_run_kernel():
     def test_func(queue, global_size, local_size, arg):
         assert all(global_size == np.array([4, 10, 3]))
         return type('Event', (object,), {'wait': lambda self: 0})()
-    with opencl.OpenCLFunctions(0) as dev:
-        dev.run_kernel(test_func, [0], threads, grid)
+    dev = opencl.OpenCLFunctions(0)
+    dev.run_kernel(test_func, [0], threads, grid)

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -233,24 +233,23 @@ def test_detect_language3():
 @skip_if_no_cuda
 def test_get_device_interface1():
     lang = "CUDA"
-    with core.DeviceInterface(core.KernelSource("", "", lang=lang)) as dev:
-        assert isinstance(dev, core.DeviceInterface)
-        assert isinstance(dev.dev, pycuda.PyCudaFunctions)
+    dev = core.DeviceInterface(core.KernelSource("", "", lang=lang))
+    assert isinstance(dev, core.DeviceInterface)
+    assert isinstance(dev.dev, pycuda.PyCudaFunctions)
 
 
 @skip_if_no_opencl
 def test_get_device_interface2():
     lang = "OpenCL"
-    with core.DeviceInterface(core.KernelSource("", "", lang=lang)) as dev:
-        assert isinstance(dev, core.DeviceInterface)
-        assert isinstance(dev.dev, opencl.OpenCLFunctions)
+    dev = core.DeviceInterface(core.KernelSource("", "", lang=lang))
+    assert isinstance(dev, core.DeviceInterface)
+    assert isinstance(dev.dev, opencl.OpenCLFunctions)
 
 
 def test_get_device_interface3():
     with raises(Exception):
         lang = "blabla"
-        with core.DeviceInterface(lang) as dev:
-            pass
+        dev = core.DeviceInterface(lang)
 
 
 def assert_user_warning(f, args, substring=None):


### PR DESCRIPTION
Instead of explicitly managing the context lifetimes, we now use the device
primary context on all cuda backends. In cupy this is (and was) the default.
In pycuda this is now enabled by the new pycuda function
retain_primary_context.

In the non-cuda backends, the context manager behaviour was not used, and
this therefore does not affect those.

Since pycuda does not wrap cuCtxSetCurrent, we do still have to use the
context stack. Mirroring pycuda.autoinit, we use atexit to pop the last
selected context to prevent pycuda from aborting with an error message
on exit.

Rationale:
This fixes the issue that KernelBuilder objects (in their current form) do
not have an explicitly defined lifetime, and therefore it is not possible to
use a context manager in them. This would lead to unpredictable context
issues if a KernelBuilder destructor would get called at the wrong time.

The new approach always uses the primary context, and therefore there is
no confusion about which context is active when.

A potential downside of dropping the context manager behaviour is that it
makes it harder to add multiple device support for KernelBuilder objects.
However, this was not supported yet anyway. Another potential downside is
reduced robustness when users manage their own cuda contexts in-between
kernel_tuner calls. This should only rarely lead to problems.