### PR TITLE
Add __version__ to __init__.py

### DIFF
--- a/kernel_tuner/__init__.py
+++ b/kernel_tuner/__init__.py
@@ -1,5 +1,4 @@
-
 from kernel_tuner.integration import store_results, create_device_targets
-
 from kernel_tuner.interface import tune_kernel, run_kernel
 
+__version__ = "0.4.2"

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,25 @@
-import sys
+import re
 from setuptools import setup
+
+
+def version():
+    with open("kernel_tuner/__init__.py") as fp:
+        match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)", fp.read())
+
+    if not match:
+        raise RuntimeError("unable to find __version__ string in __init__.py")
+
+    return match[1]
 
 
 def readme():
     with open('README.rst') as f:
         return f.read()
 
+
 setup(
     name="kernel_tuner",
-    version="0.4.2",
+    version=version(),
     author="Ben van Werkhoven",
     author_email="b.vanwerkhoven@esciencecenter.nl",
     description=("An easy to use CUDA/OpenCL kernel tuner in Python"),


### PR DESCRIPTION
It seems to be an (informal?) standard in Python to have a `__version__` attribute in `__init__.py` with the current version number of the package: https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package

I have also implemented this suggestion on this page to obtain the version number in `setup.py` by parsing  `__init__.py`: https://packaging.python.org/en/latest/guides/single-sourcing-package-version/. This prevents duplication of the version number in both files.