### PR TITLE
Add support for custom preprocessor definitions

### DIFF
--- a/examples/cuda-c++/vector_add_defines.py
+++ b/examples/cuda-c++/vector_add_defines.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+""" This is the example demonstrates how to use Kernel Tuner
+    to insert tunable parameters into template arguments
+    without using any C preprocessor defines
+"""
+
+import numpy as np
+import kernel_tuner as kt
+
+def tune():
+
+    kernel_string = """
+template<typename T, int blockSize>
+__global__ void vector_add(T *c, T *a, T *b, int n) {
+    auto i = blockIdx.x * blockSize + threadIdx.x;
+    if (i<n) {
+        c[i] = a[i] + b[i];
+    }
+}
+"""
+
+    size = 10000000
+
+    a = np.random.randn(size).astype(np.float32)
+    b = np.random.randn(size).astype(np.float32)
+    c = np.zeros_like(b)
+    n = np.int32(size)
+
+    args = [c, a, b, n]
+
+    tune_params = dict()
+    tune_params["block_size_x"] = [128+64*i for i in range(15)]
+
+    result, env = kt.tune_kernel("vector_add<float, block_size_x>", kernel_string, size, args, tune_params, defines={})
+
+    return result
+
+
+if __name__ == "__main__":
+    tune()

--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -54,11 +54,12 @@ class KernelSource(object):
     must be filenames.
     """
 
-    def __init__(self, kernel_name, kernel_sources, lang):
+    def __init__(self, kernel_name, kernel_sources, lang, defines=None):
         if not isinstance(kernel_sources, list):
             kernel_sources = [kernel_sources]
         self.kernel_sources = kernel_sources
         self.kernel_name = kernel_name
+        self.defines = defines
         if lang is None:
             if callable(self.kernel_sources[0]):
                 raise TypeError("Please specify language when using a code generator function")
@@ -128,7 +129,8 @@ class KernelSource(object):
 
             ks = self.get_kernel_string(i, params)
             # add preprocessor statements
-            n, ks = util.prepare_kernel_string(kernel_name, ks, params, grid, threads, block_size_names, self.lang)
+            n, ks = util.prepare_kernel_string(kernel_name, ks, params, grid, threads, block_size_names,
+                                               self.lang, self.defines)
 
             if i == 0:
                 # primary kernel source

--- a/kernel_tuner/interface.py
+++ b/kernel_tuner/interface.py
@@ -180,7 +180,11 @@ _kernel_options = Options([("kernel_name", ("""The name of the kernel in the cod
             'normalized_coordinates' (True/False).""", "dict(string: numpy object or dict)")),
                            ("block_size_names", ("""A list of strings that replace the defaults for the names
             that denote the thread block dimensions. If not passed, the behavior
-            defaults to ``["block_size_x", "block_size_y", "block_size_z"]``""", "list(string)"))])
+            defaults to ``["block_size_x", "block_size_y", "block_size_z"]``""", "list(string)")),
+                          ("defines", ("""A dictionary containing the preprocessor definitions inserted into
+            the source code. The keys should the definition names and each value should be either a string or 
+            a function that returns a string. If an emtpy dictionary is passed, no definitions are inserted. 
+            If None is passed, each tunable parameter is inserted as a preprocessor definition.""", "dict"))])
 
 _tuning_options = Options([("tune_params", ("""A dictionary containing the parameter names as keys,
             and lists of possible parameter settings as values.
@@ -450,13 +454,13 @@ _tune_kernel_docstring = """ Tune a CUDA kernel given a set of tunable parameter
 
 def tune_kernel(kernel_name, kernel_source, problem_size, arguments, tune_params, grid_div_x=None, grid_div_y=None, grid_div_z=None, restrictions=None,
                 answer=None, atol=1e-6, verify=None, verbose=False, lang=None, device=0, platform=0, smem_args=None, cmem_args=None, texmem_args=None,
-                compiler=None, compiler_options=None, log=None, iterations=7, block_size_names=None, quiet=False, strategy=None, strategy_options=None,
-                cache=None, metrics=None, simulation_mode=False, observers=None, objective=None, objective_higher_is_better=None):
+                compiler=None, compiler_options=None, defines=None, log=None, iterations=7, block_size_names=None, quiet=False, strategy=None,
+                strategy_options=None, cache=None, metrics=None, simulation_mode=False, observers=None, objective=None, objective_higher_is_better=None):
     start_overhead_time = perf_counter()
     if log:
         logging.basicConfig(filename=kernel_name + datetime.now().strftime('%Y%m%d-%H:%M:%S') + '.log', level=log)
 
-    kernelsource = core.KernelSource(kernel_name, kernel_source, lang)
+    kernelsource = core.KernelSource(kernel_name, kernel_source, lang, defines)
 
     _check_user_input(kernel_name, kernelsource, arguments, block_size_names)
 
@@ -599,7 +603,7 @@ _run_kernel_docstring = """Compile and run a single kernel
 
 
 def run_kernel(kernel_name, kernel_source, problem_size, arguments, params, grid_div_x=None, grid_div_y=None, grid_div_z=None, lang=None, device=0, platform=0,
-               smem_args=None, cmem_args=None, texmem_args=None, compiler=None, compiler_options=None, block_size_names=None, quiet=False, log=None):
+               smem_args=None, cmem_args=None, texmem_args=None, compiler=None, compiler_options=None, defines=None,  block_size_names=None, quiet=False, log=None):
 
     if log:
         logging.basicConfig(filename=kernel_name + datetime.now().strftime('%Y%m%d-%H:%M:%S') + '.log', level=log)

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -577,7 +577,9 @@ def prepare_kernel_string(kernel_name, kernel_string, params, grid, threads, blo
     for k, v in defines.items():
         if callable(v):
             v = v(params)
-        if not isinstance(v, str):
+        elif isinstance(v, str):
+            v = replace_param_occurrences(v, params)
+        else:
             v = str(v)
 
         if not k.isidentifier():
@@ -611,9 +613,16 @@ def read_file(filename):
 
 def replace_param_occurrences(string, params):
     """replace occurrences of the tuning params with their current value"""
-    for k, v in params.items():
-        string = string.replace(k, str(v))
-    return string
+    result = ''
+
+    # Split on tokens and replace a token if it is a key in `params`.
+    for part in re.split('([a-zA-Z0-9_]+)', string):
+        if part in params:
+            result += str(params[part])
+        else:
+            result += part
+
+    return result
 
 
 def setup_block_and_grid(problem_size, grid_div, params, block_size_names=None):

--- a/kernel_tuner/util.py
+++ b/kernel_tuner/util.py
@@ -579,13 +579,12 @@ def prepare_kernel_string(kernel_name, kernel_string, params, grid, threads, blo
             v = v(params)
         elif isinstance(v, str):
             v = replace_param_occurrences(v, params)
-        else:
-            v = str(v)
 
         if not k.isidentifier():
             raise ValueError("name is not a valid identifier: {k}")
 
         # Escape newline characters
+        v = str(v)
         v = v.replace("\n", "\\\n")
 
         if "loop_unroll_factor" in k and lang == "CUDA":
@@ -599,7 +598,7 @@ def prepare_kernel_string(kernel_name, kernel_string, params, grid, threads, blo
         else:
             kernel_string = f"#define {k} {v}\n" + kernel_string
 
-    name = kernel_name
+    name = replace_param_occurrences(kernel_name, params)
 
     return name, kernel_string
 

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -167,13 +167,13 @@ def test_prepare_kernel_string():
     params["is"] = 8
 
     _, output = prepare_kernel_string("this", kernel, params, grid, threads, block_size_names, "", None)
-    expected = "#define kernel_tuner 1\n" \
-               "#define is 8\n" \
-               "#define block_size_z 3\n" \
-               "#define block_size_y 2\n" \
-               "#define block_size_x 1\n" \
+    expected = "#define grid_size_x 3\n" \
                "#define grid_size_y 7\n" \
-               "#define grid_size_x 3\n" \
+               "#define block_size_x 1\n" \
+               "#define block_size_y 2\n" \
+               "#define block_size_z 3\n" \
+               "#define is 8\n" \
+               "#define kernel_tuner 1\n" \
                "#line 1\n" \
                "this is a weird kernel"
     assert output == expected
@@ -185,9 +185,9 @@ def test_prepare_kernel_string():
         baz=lambda config: config["is"] * 5)
 
     _, output = prepare_kernel_string("this", kernel, params, grid, threads, block_size_names, "", defines)
-    expected = "#define baz 40\n" \
+    expected = "#define foo 1\n" \
                "#define bar custom\n" \
-               "#define foo 1\n" \
+               "#define baz 40\n" \
                "#line 1\n" \
                "this is a weird kernel"
     assert output == expected

--- a/test/test_util_functions.py
+++ b/test/test_util_functions.py
@@ -206,7 +206,7 @@ def test_replace_param_occurrences():
     params["weird"] = 14
 
     new_kernel = replace_param_occurrences(kernel, params)
-    assert new_kernel == "th8 8 a 14 kernel"
+    assert new_kernel == "this 8 a 14 kernel"  # Note: The "is" in "this" should not be replaced
 
     new_kernel = replace_param_occurrences(kernel, dict())
     assert kernel == new_kernel


### PR DESCRIPTION
By default, kernel tuner inserts the tunable parameters as preprocessor parameters into the source code. However thanks to the cupy backed, these parameters can now also be inserted using template arguments, meaning the preprocessor definitions are no longer necessary. It would nice if there was a way to disable them since they can cause conflicts with external libraries (for instance, CUB uses the variable "block_size" in a few places).

This PR adds a new keyword argument `defines` to `tune_kernel` (and `run_kernel`) that allows customizing the behavior of kernel tuner around these preprocessor definitions. 

Examples:
* if `defines=None`, the behavior is identical to how it is today
* if `defines=dict()`, no preprocessor definitions are inserted, not even the default ones
* if `defines=dict(floating_type="float")`, insert `#define floating_type float`
* if `defines=dict(block_size=lambda p: p["block_size"])`, define only `block_size` 
* if `defines=dict(twice_block_size=lambda p: 2 * p["block_size"])`, insert `twice_block_size` with the value of `2 * block_size`.

Unresolved issues:
- [x] Should this keyword be called `defines` or `definitions`?
- [x] Do we need more unit-tests?
- [x] Is this behavior intuitive? An alternative would be to have a flag `disable_default_defines=True` to disable the default definitions, but this would add yet another keyword argument :-( 