### PR TITLE
Test kernelbuilder

### DIFF
--- a/kernel_tuner/core.py
+++ b/kernel_tuner/core.py
@@ -225,7 +225,7 @@ class DeviceInterface(object):
 
         logging.debug('DeviceInterface instantiated, lang=%s', lang)
 
-        if lang == "CUDA":
+        if lang.upper() == "CUDA":
             dev = PyCudaFunctions(device, compiler_options=compiler_options, iterations=iterations, observers=observers)
         elif lang.upper() == "CUPY":
             dev = CupyFunctions(device, compiler_options=compiler_options, iterations=iterations, observers=observers)

--- a/test/context.py
+++ b/test/context.py
@@ -34,6 +34,19 @@ except Exception:
 skip_if_no_cuda = pytest.mark.skipif(not cuda_present, reason="PyCuda not installed or no CUDA device detected")
 skip_if_no_cupy = pytest.mark.skipif(not cupy_present, reason="CuPy not installed")
 skip_if_no_opencl = pytest.mark.skipif(not opencl_present, reason="PyOpenCL not installed or no OpenCL device detected")
-skip_if_no_gcc = pytest.mark.skipif(not gfortran_present, reason="No gcc on PATH")
+skip_if_no_gcc = pytest.mark.skipif(not gcc_present, reason="No gcc on PATH")
 skip_if_no_gfortran = pytest.mark.skipif(not gfortran_present, reason="No gfortran on PATH")
-skip_if_no_openmp = pytest.mark.skipif(not gfortran_present, reason="No OpenMP found")
+skip_if_no_openmp = pytest.mark.skipif(not openmp_present, reason="No OpenMP found")
+
+
+def skip_backend(backend: str):
+    if backend.upper() == "CUDA" and not cuda_present:
+        pytest.skip("PyCuda not installed or no CUDA device detected")
+    elif backend.upper() == "CUPY" and not cupy_present:
+        pytest.skip("CuPy not installed")
+    elif backend.upper() == "OpenCL" and not opencl_present:
+        pytest.skip("PyOpenCL not installed or no OpenCL device detected")
+    elif backend.upper() == "C" and not gcc_present:
+        pytest.skip("No gcc on PATH")
+    elif backend.upper() == "FORTRAN" and not gfortran_present:
+        pytest.skip("No gfortran on PATH")

--- a/test/context.py
+++ b/test/context.py
@@ -27,12 +27,13 @@ openmp_present = "libgomp" in subprocess.getoutput(["ldconfig -p | grep libgomp"
 
 try:
     import cupy
+    cupy.cuda.Device(0).attributes #triggers exception if there are no CUDA-capable devices
     cupy_present = True
 except Exception:
     cupy_present = False
 
 skip_if_no_cuda = pytest.mark.skipif(not cuda_present, reason="PyCuda not installed or no CUDA device detected")
-skip_if_no_cupy = pytest.mark.skipif(not cupy_present, reason="CuPy not installed")
+skip_if_no_cupy = pytest.mark.skipif(not cupy_present, reason="CuPy not installed or no CUDA device detected")
 skip_if_no_opencl = pytest.mark.skipif(not opencl_present, reason="PyOpenCL not installed or no OpenCL device detected")
 skip_if_no_gcc = pytest.mark.skipif(not gcc_present, reason="No gcc on PATH")
 skip_if_no_gfortran = pytest.mark.skipif(not gfortran_present, reason="No gfortran on PATH")
@@ -43,7 +44,7 @@ def skip_backend(backend: str):
     if backend.upper() == "CUDA" and not cuda_present:
         pytest.skip("PyCuda not installed or no CUDA device detected")
     elif backend.upper() == "CUPY" and not cupy_present:
-        pytest.skip("CuPy not installed")
+        pytest.skip("CuPy not installed or no CUDA device detected")
     elif backend.upper() == "OpenCL" and not opencl_present:
         pytest.skip("PyOpenCL not installed or no OpenCL device detected")
     elif backend.upper() == "C" and not gcc_present:

--- a/test/test_kernelbuilder.py
+++ b/test/test_kernelbuilder.py
@@ -30,7 +30,7 @@ def test_kernel():
 def test_PythonKernel(test_kernel, backend):
     if not cuda_present:
         pytest.skip("PyCuda not installed or no CUDA device detected")
-    if not cupy_present:
+    elif not cupy_present:
         pytest.skip("CuPy not installed")
     kernel_name, kernel_string, n, args, params = test_kernel
     kernel_function = kernelbuilder.PythonKernel(*test_kernel, lang=backend)
@@ -42,7 +42,7 @@ def test_PythonKernel(test_kernel, backend):
 def test_PythonKernel_tuned(test_kernel, backend):
     if not cuda_present:
         pytest.skip("PyCuda not installed or no CUDA device detected")
-    if not cupy_present:
+    elif not cupy_present:
         pytest.skip("CuPy not installed")
     kernel_name, kernel_string, n, args, params = test_kernel
     c, a, b, n = args

--- a/test/test_kernelbuilder.py
+++ b/test/test_kernelbuilder.py
@@ -1,10 +1,13 @@
 import numpy as np
-from .context import skip_if_no_cuda
+from .context import cuda_present, cupy_present
 
 import pytest
 from kernel_tuner import kernelbuilder
 from kernel_tuner import util
 from kernel_tuner import integration
+
+
+backends = ["cuda", "cupy"]
 
 
 @pytest.fixture()
@@ -23,16 +26,24 @@ def test_kernel():
     return "vector_add", kernel_string, n, [c, a, b, n], params
 
 
-@skip_if_no_cuda
-def test_PythonKernel(test_kernel):
+@pytest.mark.parametrize("backend", backends)
+def test_PythonKernel(test_kernel, backend):
+    if not cuda_present:
+        pytest.skip("PyCuda not installed or no CUDA device detected")
+    if not cupy_present:
+        pytest.skip("CuPy not installed")
     kernel_name, kernel_string, n, args, params = test_kernel
-    kernel_function = kernelbuilder.PythonKernel(*test_kernel, lang="cupy")
+    kernel_function = kernelbuilder.PythonKernel(*test_kernel, lang=backend)
     reference = kernel_function(*args)
     assert np.allclose(reference[0], args[1]+args[2])
 
 
-@skip_if_no_cuda
-def test_PythonKernel_tuned(test_kernel):
+@pytest.mark.parametrize("backend", backends)
+def test_PythonKernel_tuned(test_kernel, backend):
+    if not cuda_present:
+        pytest.skip("PyCuda not installed or no CUDA device detected")
+    if not cupy_present:
+        pytest.skip("CuPy not installed")
     kernel_name, kernel_string, n, args, params = test_kernel
     c, a, b, n = args
     test_results_file = "test_results_file.json"
@@ -44,7 +55,7 @@ def test_PythonKernel_tuned(test_kernel):
         integration.store_results(test_results_file, kernel_name, kernel_string, params, n, [results], env)
 
         #create a kernel using the results
-        kernel_function = kernelbuilder.PythonKernel(kernel_name, kernel_string, n, args, results_file=test_results_file, lang="cupy")
+        kernel_function = kernelbuilder.PythonKernel(kernel_name, kernel_string, n, args, results_file=test_results_file, lang=backend)
 
         #test if params were retrieved correctly
         assert kernel_function.params["block_size_x"] == 384

--- a/test/test_kernelbuilder.py
+++ b/test/test_kernelbuilder.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .context import cuda_present, cupy_present
+from .context import skip_backend
 
 import pytest
 from kernel_tuner import kernelbuilder
@@ -28,10 +28,7 @@ def test_kernel():
 
 @pytest.mark.parametrize("backend", backends)
 def test_PythonKernel(test_kernel, backend):
-    if not cuda_present:
-        pytest.skip("PyCuda not installed or no CUDA device detected")
-    elif not cupy_present:
-        pytest.skip("CuPy not installed")
+    skip_backend(backend)
     kernel_name, kernel_string, n, args, params = test_kernel
     kernel_function = kernelbuilder.PythonKernel(*test_kernel, lang=backend)
     reference = kernel_function(*args)
@@ -40,10 +37,7 @@ def test_PythonKernel(test_kernel, backend):
 
 @pytest.mark.parametrize("backend", backends)
 def test_PythonKernel_tuned(test_kernel, backend):
-    if not cuda_present:
-        pytest.skip("PyCuda not installed or no CUDA device detected")
-    elif not cupy_present:
-        pytest.skip("CuPy not installed")
+    skip_backend(backend)
     kernel_name, kernel_string, n, args, params = test_kernel
     c, a, b, n = args
     test_results_file = "test_results_file.json"


### PR DESCRIPTION
Fixing issue #165 about skipping tests for the right backend.
Tests have been parameterized so that PyCUDA and CuPy backends are both tested.