### PR TITLE
Return NaN when requesting unsupported graphics voltage measurement

### DIFF
--- a/kernel_tuner/nvml.py
+++ b/kernel_tuner/nvml.py
@@ -214,10 +214,13 @@ class nvml():
     def gr_voltage(self):
         """Return current graphics voltage in millivolts"""
         args = ["nvidia-smi", "-i", str(self.id), "-q",  "-d", "VOLTAGE"]
-        result = subprocess.run(args, check=True, capture_output=True)
-        m = re.search(r"(\d+\.\d+) mV", result.stdout.decode())
-        voltage = float(m.group(1))
-        return voltage
+        try:
+            result = subprocess.run(args, check=True, capture_output=True)
+            m = re.search(r"(\d+\.\d+) mV", result.stdout.decode())
+            return float(m.group(1))
+        except:
+            self.record_gr_voltage = False
+            return np.nan
 
 
 class NVMLObserver(BenchmarkObserver):


### PR DESCRIPTION
For Ampere GPUs, one might want to include `gr_voltage` in the observables. Measuring the `gr_voltage` doesn't work on older GPUs (e.g. Volta, Turing). It is inconvenient to update the tuner scripts before running on an unsupported GPU. As a workaround, kernel tuner now logs a `NaN` when the graphics voltage could not be read and subsequent measurements of the graphics voltage are disabled.